### PR TITLE
Add documentation for published docs on rubydoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BuildingSync
 
-The BuildingSync-Gem is a repository of helpers for reading and writing BuildingSync XML files, and for using that data to drive energy simulations of the subject building. 
+The BuildingSync-Gem is a repository of helpers for reading and writing BuildingSync XML files, and for using that data to drive energy simulations of the subject building. See full documentation on [RubyDoc](https://www.rubydoc.info/github/BuildingSync/BuildingSync-gem).
 
 All of the following are supported: 
 
@@ -65,11 +65,11 @@ To generate the documentation locally do the following:
      
      $ yardoc - README.md 
      
-## Updating Rubydoc.info
-Publish documentation for each release.
+## Updating published documentation
+Publish documentation for each release:
 
 1. Tag release on GitHub
-1. Go to rubydoc.info and click `Add Project` in the upper right
+1. Go to [rubydoc.info](https://www.rubydoc.info) and click `Add Project` in the upper right
 1. Input the git address: `git://github/BuildingSync/BuildingSync-gem.git`
 1. Input the release tag for the desired version, eg: `v0.1.0`
 1. Click `Go`

--- a/README.md
+++ b/README.md
@@ -59,11 +59,21 @@ Check out the repository and then execute:
 ## Documentation
 
 The documentation of the BuildingSync-Gem is done with Yard (https://yardoc.org)
-To generate the documentation do the following:
+To generate the documentation locally do the following:
 
      $ gem install yard
      
      $ yardoc - README.md 
+     
+## Updating Rubydoc.info
+Publish documentation for each release.
+
+1. Tag release on GitHub
+1. Go to rubydoc.info and click `Add Project` in the upper right
+1. Input the git address: `git://github/BuildingSync/BuildingSync-gem.git`
+1. Input the release tag for the desired version, eg: `v0.1.0`
+1. Click `Go`
+1. Profit
     
 # Releasing
 


### PR DESCRIPTION
@nllong 

- It's not readily apparent how to remove a repo/branch once it's on rubydoc
- docs for a tag seems to work but the link to docs v0.1.0 isn't searchable on their site, though the address is still valid
    - compare https://www.rubydoc.info/github/BuildingSync/BuildingSync-gem/v0.1.0 with https://www.rubydoc.info/find/github?q=building

RubyDoc says they can integrate with github so it will publish new docs at every commit to a given branch. Do we want to do that? If so, it needs to be set up in the repo settings: https://rubydoc.tenderapp.com/kb/git-integration/adding-a-rubydocinfo-post-receive-commit-hook-on-github