### PR TITLE
Use GH Pages to host docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+# Currently deploy only builds the documentation and pushes to gh-pages
+name: Deploy
+on:
+  push:
+    branches:
+      - develop
+      - feat/build-push-docs
+jobs:
+  build-and-deploy:
+    container: nrel/openstudio:3.0.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+      - name: Install and Build
+        run: |
+          gem install bundler
+          bundle install
+          bundle exec yard - README.md
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: doc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.5'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,22 @@ on:
       - feat/build-push-docs
 jobs:
   build-and-deploy:
-    container: nrel/openstudio:3.0.1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
+
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.5'
+
       - name: Install and Build
         run: |
           gem install bundler
           bundle install
           bundle exec yard - README.md
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feat/build-push-docs
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -22,6 +21,7 @@ jobs:
           gem install bundler
           bundle install
           bundle exec yard - README.md
+          SITEMAP_BASEURL=https://buildingsync-gem.buildingsync.net bundle exec yard doc --plugin sitemap
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1

--- a/README.md
+++ b/README.md
@@ -90,20 +90,11 @@ To generate the documentation locally do the following:
 
 ```bash
 gem install yard
-yarddoc - README.md
+yard - README.md
 ```
 
-## Updating published documentation
+Documentation for the develop branch is automatically released when code is merged into the branch.
 
-Publish documentation for each release:
-
-1. Tag release on GitHub
-1. Go to [rubydoc.info](https://www.rubydoc.info) and click `Add Project` in the upper right
-1. Input the git address: `git://github/BuildingSync/BuildingSync-gem.git`
-1. Input the release tag for the desired version, eg: `v0.2.0`
-1. Click `Go`
-1. Profit
-    
 # Releasing
 
 1. Update CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BuildingSync
 
 The BuildingSync-Gem is a repository of helpers for reading and writing BuildingSync XML files, and for using that data 
-to drive energy simulations of the subject building. See full documentation on [RubyDoc](http://buildingsync-gem.buildingsync.net).
+to drive energy simulations of the subject building. See full documentation [here](https://buildingsync-gem.buildingsync.net).
 
 All of the following are supported: 
 
@@ -90,7 +90,7 @@ To generate the documentation locally do the following:
 
 ```bash
 gem install yard
-yard - README.md
+SITEMAP_BASEURL=https://buildingsync-gem.buildingsync.net bundle exec yard doc --plugin sitemap
 ```
 
 Documentation for the develop branch is automatically released when code is merged into the branch.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BuildingSync
 
 The BuildingSync-Gem is a repository of helpers for reading and writing BuildingSync XML files, and for using that data 
-to drive energy simulations of the subject building. See full documentation on [RubyDoc](https://www.rubydoc.info/github/BuildingSync/BuildingSync-gem).
+to drive energy simulations of the subject building. See full documentation on [RubyDoc](http://buildingsync-gem.buildingsync.net).
 
 All of the following are supported: 
 

--- a/buildingsync.gemspec
+++ b/buildingsync.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'yard', '~> 0.9.26'
+  spec.add_development_dependency 'yard-sitemap', '~> 1.0.1'
 end

--- a/buildingsync.gemspec
+++ b/buildingsync.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'yard', '~> 0.9.26'
 end


### PR DESCRIPTION
The rubydoc domain was down for a bit and the documentation does not appears to be hosted there anymore. This PR moves the documentation to 

https://buildingsync-gem.buildingsync.net

Resolves https://github.com/BuildingSync/project-tracker/issues/50
