### PR TITLE
renamed selection tool repo to website

### DIFF
--- a/lib/buildingsync/selection_tool.rb
+++ b/lib/buildingsync/selection_tool.rb
@@ -41,10 +41,10 @@ require 'net/http'
 require 'net/http/post/multipart'
 
 module BuildingSync
-  # Class for communicating with SelectionTool
+  # Class for communicating with SelectionTool on the BuildingSync website
   class SelectionTool
     # initialize the selection tools class
-    # @note See documentation here: https://github.com/buildingsync/selection-tool#validator
+    # @note See documentation here: https://github.com/buildingsync/buildingsync-website#validator
     # @note Use core Net::HTTPS
     # @param xml_path [String]
     def initialize(xml_path, version = '2.2.0')


### PR DESCRIPTION
#### Any background context you want to provide?
We renamed the selection-tool repository which is now part of the general BuildingSync website.

#### What does this PR do?
Renamed https://github.com/buildingsync/selection-tool to https://github.com/buildingsync/buildingsync-website

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
