### PR TITLE
Always init default systems

### DIFF
--- a/lib/buildingsync/model_articulation/facility.rb
+++ b/lib/buildingsync/model_articulation/facility.rb
@@ -212,7 +212,7 @@ module BuildingSync
       systems_xml = xget_or_create('Systems')
 
       init_hvac_systems(systems_xml.elements["#{@ns}:HVACSystems"])
-      init_lighting_systems(systems_xml.elements["#{@ns}:LightingSystem"])
+      init_lighting_systems(systems_xml.elements["#{@ns}:LightingSystems"])
       init_load_systems(systems_xml.elements["#{@ns}:PlugLoads"])  # PlugLoad, not ProcessLoad
 
     end
@@ -242,7 +242,7 @@ module BuildingSync
       else
         @lighting_systems = []
         lighting_system_xmls.elements.each do |lighting_system_xml|
-          @lighting_systems << BuildingSync::LightingSystem.new(lighting_system_xml, @ns)
+          @lighting_systems << BuildingSync::LightingSystemType.new(lighting_system_xml, @ns)
         end
       end
     end

--- a/lib/buildingsync/model_articulation/facility.rb
+++ b/lib/buildingsync/model_articulation/facility.rb
@@ -85,7 +85,7 @@ module BuildingSync
       @spaces_excluded_from_gross_floor_area = nil
 
       @load_system = nil
-      @hvac_system = nil
+      @hvac_systems = nil
 
       # reading the xml
       read_xml
@@ -209,25 +209,41 @@ module BuildingSync
 
     # read systems
     def read_and_create_initial_systems
-      hvac_xml = @g.add_hvac_system_to_facility(@base_xml)
-      lighting_xml = @g.add_lighting_system_to_facility(@base_xml)
-      @hvac_systems = HVACSystem.new(hvac_xml, @ns)
-      @lighting_system = LightingSystemType.new(lighting_xml, @ns)
+      systems_xml = xget_or_create('Systems')
+
+      init_hvac_systems(systems_xml.elements["#{@ns}:HVACSystems"])
+      init_lighting_systems(systems_xml.elements["#{@ns}:LightingSystem"])
+      # TODO: we aren't reading this from file... Which type of System is this? Plugloads? ProcessLoads?
       @load_system = LoadsSystem.new
 
-      systems_xml = xget_or_create('Systems')
-      if !systems_xml.elements.empty?
-        systems_xml.elements.each do |system_type|
-          @systems_map[system_type.name] = []
-          system_type.elements.each do |system_xml|
-            if system_xml.name == 'HVACSystem'
-              @systems_map[system_type.name] << BuildingSync::HVACSystem.new(system_xml, @ns)
-            elsif system_xml.name == 'LightingSystem'
-              @systems_map[system_type.name] << BuildingSync::LightingSystemType.new(system_xml, @ns)
-            else
-              @systems_map[system_type.name] << system_xml
-            end
-          end
+    end
+
+    def init_hvac_systems(hvac_system_xmls)
+      # if theres no hvac_system_xmls, use a default
+      if hvac_system_xmls.nil? || !hvac_system_xmls.has_elements?
+        hvac_xml = @g.add_hvac_system_to_facility(@base_xml)
+        @hvac_systems = [ HVACSystem.new(hvac_xml, @ns)]
+
+      # else, use the hvac_system_xmls
+      else
+        @hvac_systems = []
+        hvac_system_xmls.elements.each do |hvac_system_xml|
+          @hvac_systems << BuildingSync::HVACSystem.new(hvac_system_xml, @ns)
+        end
+      end
+    end
+
+    def init_lighting_systems(lighting_system_xmls)
+      # if theres no lighting_system_xmls, use a default
+      if lighting_system_xmls.nil? || !lighting_system_xmls.has_elements?
+        lighting_xml = @g.add_lighting_system_to_facility(@base_xml)
+        @lighting_systems = [LightingSystemType.new(lighting_xml, @ns)]
+
+      # else, use the lighting_system_xmls
+      else
+        @lighting_systems = []
+        lighting_system_xmls.elements.each do |lighting_system_xml|
+          @lighting_systems << BuildingSync::LightingSystem.new(lighting_system_xml, @ns)
         end
       end
     end
@@ -364,7 +380,9 @@ module BuildingSync
 
       # add_exhaust
       if add_exhaust
-        @hvac_system.add_exhaust(model, open_studio_system_standard, 'Adjacent', remove_objects)
+        @hvac_systems.each do |hvac_system|
+          hvac_system.add_exhaust(model, open_studio_system_standard, 'Adjacent', remove_objects)
+        end
       end
 
       # add service water heating demand and supply
@@ -374,7 +392,9 @@ module BuildingSync
       end
 
       # TODO: Make this better
-      @lighting_system.add_daylighting_controls(model, open_studio_system_standard, template, main_output_dir)
+      @lighting_systems.each do |lighting_system|
+        lighting_system.add_daylighting_controls(model, open_studio_system_standard, template, main_output_dir)
+      end
 
       # TODO: - add internal mass
       # TODO: - add slab modeling and slab insulation
@@ -388,12 +408,16 @@ module BuildingSync
       # works by switching some fraction of electric loads to gas if requested (assuming base load is electric)
       # add thermostats
       if add_thermostat
-        @hvac_system.add_thermostats(model, open_studio_system_standard, remove_objects)
+        @hvac_systems.each do |hvac_system|
+          hvac_system.add_thermostats(model, open_studio_system_standard, remove_objects)
+        end
       end
 
       # add hvac system
       if add_hvac
-        @hvac_system.add_hvac(model, zone_hash, open_studio_system_standard, system_type, hvac_delivery_type, htg_src, clg_src, remove_objects)
+        @hvac_systems.each do |hvac_system|
+          hvac_system.add_hvac(model, zone_hash, open_studio_system_standard, system_type, hvac_delivery_type, htg_src, clg_src, remove_objects)
+        end
       end
 
       # set hvac controls and efficiencies (this should be last model articulation element)
@@ -403,7 +427,9 @@ module BuildingSync
           objects_after_cleanup = initial_objects - model.getModelObjects.size
           OpenStudio.logFree(OpenStudio::Warn, 'BuildingSync.Facility.create_building_system', "Removing #{objects_after_cleanup} objects from model")
         end
-        @hvac_system.apply_sizing_and_assumptions(model, main_output_dir, open_studio_system_standard, primary_bldg_type, system_type, climate_zone)
+        @hvac_systems.each do |hvac_system|
+          hvac_system.apply_sizing_and_assumptions(model, main_output_dir, open_studio_system_standard, primary_bldg_type, system_type, climate_zone)
+        end
       end
 
       # remove everything but spaces, zones, and stub space types (extend as needed for additional objects, may make bool arg for this)

--- a/lib/buildingsync/model_articulation/facility.rb
+++ b/lib/buildingsync/model_articulation/facility.rb
@@ -209,6 +209,12 @@ module BuildingSync
 
     # read systems
     def read_and_create_initial_systems
+      hvac_xml = @g.add_hvac_system_to_facility(@base_xml)
+      lighting_xml = @g.add_lighting_system_to_facility(@base_xml)
+      @hvac_systems = HVACSystem.new(hvac_xml, @ns)
+      @lighting_system = LightingSystemType.new(lighting_xml, @ns)
+      @load_system = LoadsSystem.new
+
       systems_xml = xget_or_create('Systems')
       if !systems_xml.elements.empty?
         systems_xml.elements.each do |system_type|
@@ -223,12 +229,6 @@ module BuildingSync
             end
           end
         end
-      else
-        hvac_xml = @g.add_hvac_system_to_facility(@base_xml)
-        lighting_xml = @g.add_lighting_system_to_facility(@base_xml)
-        @hvac_system = HVACSystem.new(hvac_xml, @ns)
-        @lighting_system = LightingSystemType.new(lighting_xml, @ns)
-        @load_system = LoadsSystem.new
       end
     end
 

--- a/lib/buildingsync/model_articulation/facility.rb
+++ b/lib/buildingsync/model_articulation/facility.rb
@@ -388,7 +388,7 @@ module BuildingSync
 
       # add exterior lights (returns a hash where key is lighting type and value is exteriorLights object)
       if add_exterior_lights
-        if !@lighting_systems.nil?
+        if !@lighting_systems.empty?
           @lighting_systems.each do |lighting_system|
             lighting_system.add_exterior_lights(model, open_studio_system_standard, onsite_parking_fraction, exterior_lighting_zone, remove_objects)
           end

--- a/spec/files/v2.4.0/L200_Audit-1.0.0.xml
+++ b/spec/files/v2.4.0/L200_Audit-1.0.0.xml
@@ -1,0 +1,2258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Work in progress
+  This file is intended to document all of the required elements and attributes
+  for a Level 2 audit.
+-->
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 https://raw.githubusercontent.com/BuildingSync/schema/v2.5.0/BuildingSync.xsd" version="2.5.0">
+  <auc:Facilities>
+    <auc:Facility ID="Facility-A">
+      <auc:Sites>
+        <auc:Site ID="Site-A">
+          <auc:Buildings>
+            <auc:Building ID="Building-A">
+              <!-- 6.1.1.a -->
+              <auc:PremisesName>Building Name</auc:PremisesName>
+              <!-- 6.1.1.1.m and 6.1.1.2.a and 6.1.1.2.c and 6.1.1.2.d and 6.1.1.2.e -->
+              <auc:PremisesNotes>
+                Problems or Needs
+                -----------------
+                Problems or needs identified in walkthrough survey,
+                including revisions to operations and maintenance procedures
+
+                Comfort or Health Concerns
+                -----------------
+                Comfort or health concerns, including indoor environmental quality (IEQ) deficiencies
+
+                Need for Repairs
+                -----------------
+                Need for repairs
+
+                Opportunities to Improve Maintenance Practices
+                -----------------
+                Opportunities to improve maintenance practices
+
+                Other Conditions Causing Unusual Operating Costs
+                -----------------
+                Other conditions causing unusual operating costs
+              </auc:PremisesNotes>
+              <!-- 6.1.1.1.d -->
+              <auc:Address>
+                <auc:StreetAddressDetail>
+                  <auc:Simplified>
+                    <auc:StreetAddress>
+                      123 Main Street
+                    </auc:StreetAddress>
+                  </auc:Simplified>
+                </auc:StreetAddressDetail>
+                <auc:City>Rome</auc:City>
+                <auc:State>GA</auc:State>
+                <auc:PostalCode>30161</auc:PostalCode>
+              </auc:Address>
+              <!-- 6.1.1.1.f -->
+              <auc:BuildingClassification>Mixed use commercial</auc:BuildingClassification>
+              <auc:OccupancyClassification>Office</auc:OccupancyClassification>
+              <!-- 6.1.1.1.k -->
+              <!--
+                Note that this is only required if building classification is residential,
+                ie auc:BuildingClassification='Mixed use commercial' or auc:BuildingClassification='Residential'
+              -->
+              <auc:SpatialUnits>
+                <auc:SpatialUnit>
+                  <auc:SpatialUnitType>Apartment units</auc:SpatialUnitType>
+                  <auc:NumberOfUnits>1</auc:NumberOfUnits>
+                  <auc:SpatialUnitOccupiedPercentage>100</auc:SpatialUnitOccupiedPercentage>
+                </auc:SpatialUnit>
+              </auc:SpatialUnits>
+              <auc:PrimaryContactID IDref="Contact-A"/>
+              <!-- 6.1.1.1.h -->
+              <auc:FloorsAboveGrade>2</auc:FloorsAboveGrade>
+              <auc:FloorsBelowGrade>1</auc:FloorsBelowGrade>
+              <auc:ConditionedFloorsAboveGrade>1</auc:ConditionedFloorsAboveGrade>
+              <auc:ConditionedFloorsBelowGrade>1</auc:ConditionedFloorsBelowGrade>
+              <auc:BuildingAutomationSystem>true</auc:BuildingAutomationSystem>
+              <!-- 6.1.1.2.b -->
+              <auc:HistoricalLandmark>true</auc:HistoricalLandmark>
+              <!-- 6.1.1.1.e -->
+              <auc:FloorAreas>
+                <auc:FloorArea>
+                  <auc:FloorAreaType>Gross</auc:FloorAreaType>
+                  <auc:FloorAreaValue>5502</auc:FloorAreaValue>
+                  <auc:ExcludedSectionIDs>
+                    <auc:ExcludedSectionID IDref="Section-Space-B"/>
+                  </auc:ExcludedSectionIDs>
+                </auc:FloorArea>
+                <auc:FloorArea>
+                  <auc:FloorAreaType>Conditioned</auc:FloorAreaType>
+                  <auc:FloorAreaValue>5502</auc:FloorAreaValue>
+                  <auc:ExcludedSectionIDs>
+                    <auc:ExcludedSectionID IDref="Section-Space-B"/>
+                  </auc:ExcludedSectionIDs>
+                </auc:FloorArea>
+              </auc:FloorAreas>
+              <auc:TotalExteriorAboveGradeWallArea>123</auc:TotalExteriorAboveGradeWallArea>
+              <auc:TotalExteriorBelowGradeWallArea>123</auc:TotalExteriorBelowGradeWallArea>
+              <auc:OverallWindowToWallRatio>0.2</auc:OverallWindowToWallRatio>
+              <auc:OverallDoorToWallRatio>0.1</auc:OverallDoorToWallRatio>
+              <!-- 6.1.1.1.i -->
+              <auc:YearOfConstruction>1993</auc:YearOfConstruction>
+              <!-- 6.1.1.1.l (recommended) -->
+              <auc:YearOfLastEnergyAudit>2018</auc:YearOfLastEnergyAudit>
+              <!-- 6.2.1.1 (recommended) -->
+              <auc:RetrocommissioningDate>2020-03-01</auc:RetrocommissioningDate>
+              <!-- 6.1.1.1.i -->
+              <auc:YearOfLastMajorRemodel>2016</auc:YearOfLastMajorRemodel>
+              <!-- 6.1.1.1g (for every space function) -->
+              <auc:Sections>
+                <auc:Section ID="Section-Space-A">
+                  <auc:SectionType>Space function</auc:SectionType>
+                  <auc:OccupancyClassification>Office</auc:OccupancyClassification>
+                  <auc:OriginalOccupancyClassification>Office</auc:OriginalOccupancyClassification>
+                  <!-- 6.1.1.1.g/5.3.4.d -->
+                  <auc:OccupancyLevels>
+                    <auc:OccupancyLevel>
+                      <!-- note, type can also be 'Normal Occupancy' -->
+                      <auc:OccupantQuantityType>Peak total occupants</auc:OccupantQuantityType>
+                      <auc:OccupantQuantity>123</auc:OccupantQuantity>
+                    </auc:OccupancyLevel>
+                  </auc:OccupancyLevels>
+                  <auc:TypicalOccupantUsages>
+                    <!-- 6.1.1.1.g/5.3.4.b -->
+                    <auc:TypicalOccupantUsage>
+                      <auc:TypicalOccupantUsageValue>40</auc:TypicalOccupantUsageValue>
+                      <auc:TypicalOccupantUsageUnits>Hours per week</auc:TypicalOccupantUsageUnits>
+                    </auc:TypicalOccupantUsage>
+                    <!-- 6.1.1.1.g/5.3.4.c -->
+                    <auc:TypicalOccupantUsage>
+                      <auc:TypicalOccupantUsageValue>30</auc:TypicalOccupantUsageValue>
+                      <auc:TypicalOccupantUsageUnits>Weeks per year</auc:TypicalOccupantUsageUnits>
+                    </auc:TypicalOccupantUsage>
+                  </auc:TypicalOccupantUsages>
+                  <auc:FloorAreas>
+                    <!-- 6.1.1.1.g/5.3.4.a -->
+                    <auc:FloorArea>
+                      <auc:FloorAreaType>Gross</auc:FloorAreaType>
+                      <auc:FloorAreaValue>123</auc:FloorAreaValue>
+                    </auc:FloorArea>
+                    <auc:FloorArea>
+                      <auc:FloorAreaType>Conditioned</auc:FloorAreaType>
+                      <auc:FloorAreaValue>23</auc:FloorAreaValue>
+                    </auc:FloorArea>
+                  </auc:FloorAreas>
+                  <auc:ThermalZoneLayout>Single zone</auc:ThermalZoneLayout>
+                </auc:Section>
+                <auc:Section ID="Section-Space-B">
+                  <auc:SectionType>Space function</auc:SectionType>
+                  <auc:OccupancyClassification>Multifamily</auc:OccupancyClassification>
+                  <auc:OriginalOccupancyClassification>Other</auc:OriginalOccupancyClassification>
+                  <!-- 6.1.1.1.g/5.3.4.d -->
+                  <auc:OccupancyLevels>
+                    <auc:OccupancyLevel>
+                      <!-- note, type can also be 'Normal Occupancy' -->
+                      <auc:OccupantQuantityType>Peak total occupants</auc:OccupantQuantityType>
+                      <auc:OccupantQuantity>123</auc:OccupantQuantity>
+                    </auc:OccupancyLevel>
+                  </auc:OccupancyLevels>
+                  <auc:TypicalOccupantUsages>
+                    <!-- 6.1.1.1.g/5.3.4.b -->
+                    <auc:TypicalOccupantUsage>
+                      <auc:TypicalOccupantUsageValue>40</auc:TypicalOccupantUsageValue>
+                      <auc:TypicalOccupantUsageUnits>Hours per week</auc:TypicalOccupantUsageUnits>
+                    </auc:TypicalOccupantUsage>
+                    <!-- 6.1.1.1.g/5.3.4.c -->
+                    <auc:TypicalOccupantUsage>
+                      <auc:TypicalOccupantUsageValue>30</auc:TypicalOccupantUsageValue>
+                      <auc:TypicalOccupantUsageUnits>Weeks per year</auc:TypicalOccupantUsageUnits>
+                    </auc:TypicalOccupantUsage>
+                  </auc:TypicalOccupantUsages>
+                  <auc:FloorAreas>
+                    <!-- 6.1.1.1.g/5.3.4.a -->
+                    <auc:FloorArea>
+                      <auc:FloorAreaType>Gross</auc:FloorAreaType>
+                      <auc:FloorAreaValue>10</auc:FloorAreaValue>
+                    </auc:FloorArea>
+                    <auc:FloorArea>
+                      <auc:FloorAreaType>Conditioned</auc:FloorAreaType>
+                      <auc:FloorAreaValue>10</auc:FloorAreaValue>
+                    </auc:FloorArea>
+                  </auc:FloorAreas>
+                  <auc:ThermalZoneLayout>Single zone</auc:ThermalZoneLayout>
+                </auc:Section>
+                <auc:Section ID="Section-Whole-building">
+                  <auc:SectionType>Whole building</auc:SectionType>
+                  <auc:FootprintShape>Rectangular</auc:FootprintShape>
+                  <auc:Sides>
+                    <auc:Side>
+                      <auc:SideNumber>A1</auc:SideNumber>
+                      <auc:WallIDs>
+                        <auc:WallID IDref="Wall-A">
+                          <auc:WallArea>123</auc:WallArea>
+                        </auc:WallID>
+                      </auc:WallIDs>
+                      <auc:WindowIDs>
+                        <auc:WindowID IDref="Window-A-Original">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:WindowID>
+                      </auc:WindowIDs>
+                      <auc:DoorIDs>
+                        <auc:DoorID IDref="Door-A">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:DoorID>
+                      </auc:DoorIDs>
+                    </auc:Side>
+                    <auc:Side>
+                      <auc:SideNumber>B1</auc:SideNumber>
+                      <auc:WallIDs>
+                        <auc:WallID IDref="Wall-A">
+                          <auc:WallArea>123</auc:WallArea>
+                        </auc:WallID>
+                      </auc:WallIDs>
+                      <auc:WindowIDs>
+                        <auc:WindowID IDref="Window-A-Original">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:WindowID>
+                      </auc:WindowIDs>
+                      <auc:DoorIDs>
+                        <auc:DoorID IDref="Door-A">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:DoorID>
+                      </auc:DoorIDs>
+                    </auc:Side>
+                    <auc:Side>
+                      <auc:SideNumber>C1</auc:SideNumber>
+                      <auc:WallIDs>
+                        <auc:WallID IDref="Wall-A">
+                          <auc:WallArea>123</auc:WallArea>
+                        </auc:WallID>
+                      </auc:WallIDs>
+                      <auc:WindowIDs>
+                        <auc:WindowID IDref="Window-A-Original">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:WindowID>
+                      </auc:WindowIDs>
+                      <auc:DoorIDs>
+                        <auc:DoorID IDref="Door-A">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:DoorID>
+                      </auc:DoorIDs>
+                    </auc:Side>
+                    <auc:Side>
+                      <auc:SideNumber>D1</auc:SideNumber>
+                      <auc:WallIDs>
+                        <auc:WallID IDref="Wall-A">
+                          <auc:WallArea>123</auc:WallArea>
+                        </auc:WallID>
+                      </auc:WallIDs>
+                      <auc:WindowIDs>
+                        <auc:WindowID IDref="Window-A-Original">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:WindowID>
+                      </auc:WindowIDs>
+                      <auc:DoorIDs>
+                        <auc:DoorID IDref="Door-A">
+                          <auc:FenestrationArea>123</auc:FenestrationArea>
+                        </auc:DoorID>
+                      </auc:DoorIDs>
+                    </auc:Side>
+                  </auc:Sides>
+                  <auc:Roofs>
+                    <auc:Roof>
+                      <auc:RoofID IDref="Roof-A">
+                        <auc:RoofArea>123</auc:RoofArea>
+                        <auc:RoofCondition>Excellent</auc:RoofCondition>
+                      </auc:RoofID>
+                    </auc:Roof>
+                  </auc:Roofs>
+                  <auc:Foundations>
+                    <auc:Foundation>
+                      <auc:FoundationID IDref="Foundation-A">
+                        <auc:FoundationArea>123</auc:FoundationArea>
+                      </auc:FoundationID>
+                    </auc:Foundation>
+                  </auc:Foundations>
+                </auc:Section>
+              </auc:Sections>
+            </auc:Building>
+          </auc:Buildings>
+        </auc:Site>
+      </auc:Sites>
+      <auc:Systems>
+        <auc:HVACSystems>
+          <!-- 6.1.1.1.g/5.3.4.g (for every space function) -->
+          <auc:HVACSystem ID="HVAC-A">
+            <auc:Plants>
+              <auc:CoolingPlants>
+                <auc:CoolingPlant ID="CoolingPlant-A">
+                  <auc:DistrictChilledWater>
+                    <auc:AnnualCoolingEfficiencyValue>123</auc:AnnualCoolingEfficiencyValue>
+                    <auc:AnnualCoolingEfficiencyUnits>COP</auc:AnnualCoolingEfficiencyUnits>
+                    <auc:Capacity>123</auc:Capacity>
+                    <auc:CapacityUnits>gpm</auc:CapacityUnits>
+                  </auc:DistrictChilledWater>
+                  <auc:CoolingPlantCondition>Good</auc:CoolingPlantCondition>
+                  <auc:YearInstalled>2020</auc:YearInstalled>
+                  <auc:PrimaryFuel>Other</auc:PrimaryFuel>
+                  <auc:BuildingAutomationSystem>true</auc:BuildingAutomationSystem>
+                  <auc:ControlSystemTypes>
+                    <auc:ControlSystemType>
+                      <auc:Digital/>
+                    </auc:ControlSystemType>
+                  </auc:ControlSystemTypes>
+                </auc:CoolingPlant>
+              </auc:CoolingPlants>
+            </auc:Plants>
+            <auc:HeatingAndCoolingSystems>
+              <auc:ZoningSystemType>Single zone</auc:ZoningSystemType>
+              <auc:HeatingSources>
+                <auc:HeatingSource ID="HeatingSource-A">
+                  <auc:HeatingSourceType>
+                    <auc:Furnace>
+                      <auc:FurnaceType>Warm air</auc:FurnaceType>
+                    </auc:Furnace>
+                  </auc:HeatingSourceType>
+                  <auc:AnnualHeatingEfficiencyValue>123</auc:AnnualHeatingEfficiencyValue>
+                  <auc:AnnualHeatingEfficiencyUnits>COP</auc:AnnualHeatingEfficiencyUnits>
+                  <auc:InputCapacity>123</auc:InputCapacity>
+                  <auc:Capacity>123</auc:Capacity>
+                  <auc:CapacityUnits>gpm</auc:CapacityUnits>
+                  <auc:HeatingSourceCondition>Good</auc:HeatingSourceCondition>
+                  <auc:Controls>
+                    <auc:Control>
+                      <auc:OtherControlTechnology>
+                        <auc:ControlSystemType>
+                          <auc:Digital/>
+                        </auc:ControlSystemType>
+                      </auc:OtherControlTechnology>
+                    </auc:Control>
+                  </auc:Controls>
+                  <auc:YearInstalled>2020</auc:YearInstalled>
+                </auc:HeatingSource>
+              </auc:HeatingSources>
+              <auc:CoolingSources>
+                <auc:CoolingSource ID="CoolingSource-A">
+                  <auc:CoolingSourceType>
+                    <auc:CoolingPlantID IDref="CoolingPlant-A"/>
+                  </auc:CoolingSourceType>
+                </auc:CoolingSource>
+              </auc:CoolingSources>
+              <auc:Deliveries>
+                <auc:Delivery ID="Delivery-A">
+                  <auc:DeliveryType>
+                    <auc:CentralAirDistribution>
+                      <auc:AirDeliveryType>Central fan</auc:AirDeliveryType>
+                      <auc:TerminalUnit>CAV terminal box no reheat</auc:TerminalUnit>
+                      <auc:ReheatSource>None</auc:ReheatSource>
+                      <auc:FanBased>
+                        <auc:AirSideEconomizer ID="AirSideEconomizer-A">
+                          <auc:AirSideEconomizerType>None</auc:AirSideEconomizerType>
+                          <auc:EconomizerControl>Fixed</auc:EconomizerControl>
+                        </auc:AirSideEconomizer>
+                      </auc:FanBased>
+                    </auc:CentralAirDistribution>
+                  </auc:DeliveryType>
+                  <auc:HeatingSourceID IDref="HeatingSource-A"/>
+                  <auc:CoolingSourceID IDref="CoolingSource-A"/>
+                  <auc:Controls>
+                    <auc:Control>
+                      <auc:OtherControlTechnology>
+                        <auc:ControlSystemType>
+                          <auc:Digital/>
+                        </auc:ControlSystemType>
+                      </auc:OtherControlTechnology>
+                    </auc:Control>
+                  </auc:Controls>
+                  <auc:YearInstalled>2020</auc:YearInstalled>
+                  <auc:Quantity>1</auc:Quantity>
+                  <auc:DeliveryCondition>Good</auc:DeliveryCondition>
+                </auc:Delivery>
+              </auc:Deliveries>
+            </auc:HeatingAndCoolingSystems>
+            <auc:DuctSystems>
+              <auc:DuctSystem ID="DuctSystem-A">
+                <auc:DuctConfiguration>Single</auc:DuctConfiguration>
+                <auc:DuctInsulationCondition>Excellent</auc:DuctInsulationCondition>
+                <auc:HeatingDeliveryID IDref="Delivery-A"/>
+                <auc:CoolingDeliveryID IDref="Delivery-A"/>
+              </auc:DuctSystem>
+            </auc:DuctSystems>
+            <auc:HVACControlSystemTypes>
+              <auc:HVACControlSystemType>Digital</auc:HVACControlSystemType>
+            </auc:HVACControlSystemTypes>
+            <auc:LinkedPremises>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Space-A">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="HVACSchedule"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+                <auc:LinkedSectionID IDref="Section-Space-B">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="HVACSchedule"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+              </auc:Section>
+            </auc:LinkedPremises>
+          </auc:HVACSystem>
+        </auc:HVACSystems>
+        <auc:LightingSystems>
+          <auc:LightingSystem ID="LightingSystem-A">
+            <auc:LampType>
+              <auc:CompactFluorescent>
+                <auc:LampLabel>Spiral</auc:LampLabel>
+              </auc:CompactFluorescent>
+            </auc:LampType>
+            <auc:BallastType>Standard Electronic</auc:BallastType>
+            <auc:DimmingCapability>
+              <auc:MinimumDimmingLightFraction>.2</auc:MinimumDimmingLightFraction>
+            </auc:DimmingCapability>
+            <auc:PercentPremisesServed>100</auc:PercentPremisesServed>
+            <auc:InstalledPower>123</auc:InstalledPower>
+            <auc:LampPower>123</auc:LampPower>
+            <auc:NumberOfLampsPerBallast>1</auc:NumberOfLampsPerBallast>
+            <auc:NumberOfBallastsPerLuminaire>1</auc:NumberOfBallastsPerLuminaire>
+            <auc:NumberOfLuminaires>1</auc:NumberOfLuminaires>
+            <auc:OutsideLighting>false</auc:OutsideLighting>
+            <auc:Controls>
+              <auc:Control>
+                <auc:Daylighting>
+                  <auc:ControlSystemType>
+                    <auc:Digital/>
+                  </auc:ControlSystemType>
+                  <auc:ControlSensor>Photocell</auc:ControlSensor>
+                  <auc:ControlStrategy>Continuous</auc:ControlStrategy>
+                </auc:Daylighting>
+              </auc:Control>
+            </auc:Controls>
+            <auc:LightingAutomationSystem>false</auc:LightingAutomationSystem>
+            <auc:LinkedPremises>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Space-A">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="LightingSchedule-Original"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+                <auc:LinkedSectionID IDref="Section-Space-B">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="LightingSchedule-Original"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+              </auc:Section>
+            </auc:LinkedPremises>
+          </auc:LightingSystem>
+        </auc:LightingSystems>
+        <auc:DomesticHotWaterSystems>
+          <auc:DomesticHotWaterSystem ID="DHW-A">
+            <auc:DomesticHotWaterType>
+              <auc:HeatExchanger/>
+            </auc:DomesticHotWaterType>
+            <auc:DomesticHotWaterSystemNotes>Notes</auc:DomesticHotWaterSystemNotes>
+            <auc:Recirculation>
+              <auc:RecirculationLoopCount>1</auc:RecirculationLoopCount>
+              <auc:RecirculationFlowRate>123</auc:RecirculationFlowRate>
+              <auc:RecirculationControlType>Continuous</auc:RecirculationControlType>
+              <auc:PipeInsulationThickness>123</auc:PipeInsulationThickness>
+              <auc:RecirculationEnergyLossRate>123</auc:RecirculationEnergyLossRate>
+            </auc:Recirculation>
+            <auc:HotWaterDistributionType>Looped</auc:HotWaterDistributionType>
+            <auc:WaterHeaterEfficiencyType>COP</auc:WaterHeaterEfficiencyType>
+            <auc:WaterHeaterEfficiency>123</auc:WaterHeaterEfficiency>
+            <auc:DailyHotWaterDraw>123</auc:DailyHotWaterDraw>
+            <auc:HotWaterSetpointTemperature>123</auc:HotWaterSetpointTemperature>
+            <auc:ParasiticFuelConsumptionRate>123</auc:ParasiticFuelConsumptionRate>
+            <auc:Capacity>123</auc:Capacity>
+            <auc:CapacityUnits>gpm</auc:CapacityUnits>
+            <auc:Controls>
+              <auc:Control>
+                <auc:Manual>
+                  <auc:ControlSystemType>
+                    <auc:Other/>
+                  </auc:ControlSystemType>
+                </auc:Manual>
+              </auc:Control>
+            </auc:Controls>
+            <auc:PrimaryFuel>Electricity</auc:PrimaryFuel>
+            <auc:DomesticHotWaterSystemCondition>Excellent</auc:DomesticHotWaterSystemCondition>
+            <auc:LinkedPremises>
+              <auc:Building>
+                <auc:LinkedBuildingID IDref="Building-A"/>
+              </auc:Building>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Space-A"/>
+                <auc:LinkedSectionID IDref="Section-Space-B"/>
+              </auc:Section>
+            </auc:LinkedPremises>
+            <auc:Quantity>123</auc:Quantity>
+          </auc:DomesticHotWaterSystem>
+        </auc:DomesticHotWaterSystems>
+        <auc:PumpSystems>
+          <auc:PumpSystem ID="PumpSystem-B">
+            <auc:PumpEfficiency>123</auc:PumpEfficiency>
+            <auc:PumpMaximumFlowRate>123</auc:PumpMaximumFlowRate>
+            <auc:PumpInstalledFlowRate>123</auc:PumpInstalledFlowRate>
+            <auc:PumpControlType>Constant Volume</auc:PumpControlType>
+            <auc:LinkedSystemIDs>
+              <auc:LinkedSystemID IDref="CoolingPlant-A"/>
+            </auc:LinkedSystemIDs>
+          </auc:PumpSystem>
+        </auc:PumpSystems>
+        <auc:FanSystems>
+          <auc:FanSystem ID="FanSystem-A">
+            <auc:FanEfficiency>123</auc:FanEfficiency>
+            <auc:FanSize>123</auc:FanSize>
+            <auc:InstalledFlowRate>123</auc:InstalledFlowRate>
+            <auc:FanControlType>Stepped</auc:FanControlType>
+            <auc:LinkedSystemIDs>
+              <auc:LinkedSystemID IDref="Delivery-A"/>
+            </auc:LinkedSystemIDs>
+          </auc:FanSystem>
+        </auc:FanSystems>
+        <auc:WallSystems>
+          <auc:WallSystem ID="Wall-A">
+            <auc:ExteriorWallConstruction>Concrete poured</auc:ExteriorWallConstruction>
+            <auc:WallRValue>1</auc:WallRValue>
+          </auc:WallSystem>
+        </auc:WallSystems>
+        <auc:RoofSystems>
+          <auc:RoofSystem ID="Roof-A">
+            <auc:RoofConstruction>Wood frame</auc:RoofConstruction>
+            <auc:RoofRValue>1</auc:RoofRValue>
+          </auc:RoofSystem>
+        </auc:RoofSystems>
+        <auc:FenestrationSystems>
+          <auc:FenestrationSystem ID="Window-A-Original">
+            <auc:FenestrationType>
+              <auc:Window/>
+            </auc:FenestrationType>
+            <auc:FenestrationFrameMaterial>Steel</auc:FenestrationFrameMaterial>
+            <auc:GlassType>Clear uncoated</auc:GlassType>
+            <auc:FenestrationGlassLayers>Single pane</auc:FenestrationGlassLayers>
+            <auc:FenestrationUFactor>1.25</auc:FenestrationUFactor>
+            <auc:SolarHeatGainCoefficient>0.5</auc:SolarHeatGainCoefficient>
+            <auc:VisibleTransmittance>0.5</auc:VisibleTransmittance>
+          </auc:FenestrationSystem>
+          <auc:FenestrationSystem ID="Window-A-New">
+            <auc:FenestrationType>
+              <auc:Window/>
+            </auc:FenestrationType>
+            <auc:FenestrationFrameMaterial>Steel</auc:FenestrationFrameMaterial>
+            <auc:GlassType>Low e</auc:GlassType>
+            <auc:FenestrationGlassLayers>Triple pane</auc:FenestrationGlassLayers>
+            <auc:FenestrationUFactor>0.25</auc:FenestrationUFactor>
+            <auc:SolarHeatGainCoefficient>0.5</auc:SolarHeatGainCoefficient>
+            <auc:VisibleTransmittance>0.5</auc:VisibleTransmittance>
+          </auc:FenestrationSystem>
+          <auc:FenestrationSystem ID="Door-A">
+            <auc:FenestrationType>
+              <auc:Door>
+                <auc:ExteriorDoorType>Insulated metal</auc:ExteriorDoorType>
+                <auc:DoorGlazedAreaFraction>0.5</auc:DoorGlazedAreaFraction>
+              </auc:Door>
+            </auc:FenestrationType>
+            <auc:FenestrationFrameMaterial>Steel</auc:FenestrationFrameMaterial>
+            <auc:FenestrationRValue>0.5</auc:FenestrationRValue>
+          </auc:FenestrationSystem>
+        </auc:FenestrationSystems>
+        <auc:FoundationSystems>
+          <auc:FoundationSystem ID="Foundation-A">
+            <auc:GroundCouplings>
+              <auc:GroundCoupling>
+                <auc:SlabOnGrade>
+                  <auc:SlabUFactor>0.5</auc:SlabUFactor>
+                </auc:SlabOnGrade>
+              </auc:GroundCoupling>
+            </auc:GroundCouplings>
+            <auc:FloorConstructionType>Concrete poured</auc:FloorConstructionType>
+          </auc:FoundationSystem>
+        </auc:FoundationSystems>
+        <auc:PlugLoads>
+          <!-- 6.1.1.1.g/5.3.4.e (for every space function) -->
+          <auc:PlugLoad ID="PlugLoad-A">
+            <auc:WeightedAverageLoad>123</auc:WeightedAverageLoad>
+            <auc:LinkedPremises>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Space-A">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="PlugLoadSchedule"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+                <auc:LinkedSectionID IDref="Section-Space-B">
+                  <auc:LinkedScheduleIDs>
+                    <auc:LinkedScheduleID IDref="PlugLoadSchedule"/>
+                  </auc:LinkedScheduleIDs>
+                </auc:LinkedSectionID>
+              </auc:Section>
+            </auc:LinkedPremises>
+          </auc:PlugLoad>
+        </auc:PlugLoads>
+        <!-- 6.2.1.1.f.1 -->
+        <auc:OnsiteStorageTransmissionGenerationSystems>
+          <auc:OnsiteStorageTransmissionGenerationSystem ID="PVSystem">
+            <auc:EnergyConversionType>
+              <auc:Generation>
+                <auc:OnsiteGenerationType>
+                  <auc:PV>
+                    <auc:PhotovoltaicSystemMaximumPowerOutput>123</auc:PhotovoltaicSystemMaximumPowerOutput>
+                    <auc:PhotovoltaicSystemInverterEfficiency>123</auc:PhotovoltaicSystemInverterEfficiency>
+                  </auc:PV>
+                </auc:OnsiteGenerationType>
+              </auc:Generation>
+            </auc:EnergyConversionType>
+          </auc:OnsiteStorageTransmissionGenerationSystem>
+          <auc:OnsiteStorageTransmissionGenerationSystem ID="MictoturbineSystem">
+            <auc:EnergyConversionType>
+              <auc:Generation>
+                <auc:OnsiteGenerationType>
+                  <auc:Other>
+                    <auc:OtherEnergyGenerationTechnology>Microturbine</auc:OtherEnergyGenerationTechnology>
+                    <auc:OutputResourceType>Electricity</auc:OutputResourceType>
+                  </auc:Other>
+                </auc:OnsiteGenerationType>
+              </auc:Generation>
+            </auc:EnergyConversionType>
+          </auc:OnsiteStorageTransmissionGenerationSystem>
+          <auc:OnsiteStorageTransmissionGenerationSystem ID="BatterySystem">
+            <auc:EnergyConversionType>
+              <auc:Storage>
+                <auc:EnergyStorageTechnology>Battery</auc:EnergyStorageTechnology>
+              </auc:Storage>
+            </auc:EnergyConversionType>
+            <auc:Capacity>123</auc:Capacity>
+            <auc:CapacityUnits>kW</auc:CapacityUnits>
+          </auc:OnsiteStorageTransmissionGenerationSystem>
+        </auc:OnsiteStorageTransmissionGenerationSystems>
+        <auc:AirInfiltrationSystems>
+          <auc:AirInfiltrationSystem ID="AirInfiltration-A">
+            <auc:AirInfiltrationNotes>Notes on the test conducted</auc:AirInfiltrationNotes>
+            <auc:Tightness>Very Tight</auc:Tightness>
+            <auc:AirInfiltrationValue>123</auc:AirInfiltrationValue>
+            <auc:AirInfiltrationValueUnits>CFM25</auc:AirInfiltrationValueUnits>
+            <auc:AirInfiltrationTest>Blower door</auc:AirInfiltrationTest>
+            <auc:LinkedPremises>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Whole-building"/>
+              </auc:Section>
+            </auc:LinkedPremises>
+          </auc:AirInfiltrationSystem>
+        </auc:AirInfiltrationSystems>
+        <auc:WaterInfiltrationSystems>
+          <auc:WaterInfiltrationSystem>
+            <auc:WaterInfiltrationNotes>Notes on the test conducted</auc:WaterInfiltrationNotes>
+            <auc:LinkedPremises>
+              <auc:Section>
+                <auc:LinkedSectionID IDref="Section-Whole-building"/>
+              </auc:Section>
+            </auc:LinkedPremises>
+          </auc:WaterInfiltrationSystem>
+        </auc:WaterInfiltrationSystems>
+      </auc:Systems>
+      <auc:Schedules>
+        <auc:Schedule ID="OccupancySchedule">
+          <auc:ScheduleDetails>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekday</auc:DayType>
+              <auc:ScheduleCategory>Occupied</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekend</auc:DayType>
+              <auc:ScheduleCategory>Occupied</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Holiday</auc:DayType>
+              <auc:ScheduleCategory>Occupied</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+          </auc:ScheduleDetails>
+          <auc:LinkedPremises>
+            <auc:Section>
+              <auc:LinkedSectionID IDref="Section-Space-A"/>
+              <auc:LinkedSectionID IDref="Section-Space-B"/>
+            </auc:Section>
+          </auc:LinkedPremises>
+        </auc:Schedule>
+        <auc:Schedule ID="LightingSchedule-Original">
+          <auc:ScheduleDetails>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekday</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekend</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Holiday</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+          </auc:ScheduleDetails>
+          <auc:LinkedPremises>
+            <auc:Building>
+              <auc:LinkedBuildingID IDref="Building-A"/>
+            </auc:Building>
+          </auc:LinkedPremises>
+        </auc:Schedule>
+        <auc:Schedule ID="LightingSchedule-New">
+          <auc:ScheduleDetails>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekday</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>40</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekend</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>12:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>40</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Holiday</auc:DayType>
+              <auc:ScheduleCategory>Lighting</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>0</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+          </auc:ScheduleDetails>
+          <auc:LinkedPremises>
+            <auc:Building>
+              <auc:LinkedBuildingID IDref="Building-A"/>
+            </auc:Building>
+          </auc:LinkedPremises>
+        </auc:Schedule>
+        <auc:Schedule ID="HVACSchedule">
+          <auc:ScheduleDetails>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekday</auc:DayType>
+              <auc:ScheduleCategory>HVAC equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekend</auc:DayType>
+              <auc:ScheduleCategory>HVAC equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Holiday</auc:DayType>
+              <auc:ScheduleCategory>HVAC equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+          </auc:ScheduleDetails>
+          <auc:LinkedPremises>
+            <auc:Building>
+              <auc:LinkedBuildingID IDref="Building-A"/>
+            </auc:Building>
+          </auc:LinkedPremises>
+        </auc:Schedule>
+        <auc:Schedule ID="PlugLoadSchedule">
+          <auc:ScheduleDetails>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekday</auc:DayType>
+              <auc:ScheduleCategory>Miscellaneous equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Weekend</auc:DayType>
+              <auc:ScheduleCategory>Miscellaneous equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+            <auc:ScheduleDetail>
+              <auc:DayType>Holiday</auc:DayType>
+              <auc:ScheduleCategory>Miscellaneous equipment</auc:ScheduleCategory>
+              <auc:DayStartTime>09:00:00</auc:DayStartTime>
+              <auc:DayEndTime>17:00:00</auc:DayEndTime>
+              <auc:PartialOperationPercentage>80</auc:PartialOperationPercentage>
+            </auc:ScheduleDetail>
+          </auc:ScheduleDetails>
+          <auc:LinkedPremises>
+            <auc:Building>
+              <auc:LinkedBuildingID IDref="Building-A"/>
+            </auc:Building>
+          </auc:LinkedPremises>
+        </auc:Schedule>
+      </auc:Schedules>
+      <auc:Measures>
+        <!-- Low cost measure -->
+        <auc:Measure ID="Measure-LowCost-A">
+          <auc:TypeOfMeasure>
+            <auc:ModificationRetrocommissions>
+              <auc:ModificationRetrocommissioning>
+                <auc:ExistingScheduleAffected IDref="LightingSchedule-Original"/>
+                <auc:ModifiedSchedule IDref="LightingSchedule-New"/>
+              </auc:ModificationRetrocommissioning>
+            </auc:ModificationRetrocommissions>
+          </auc:TypeOfMeasure>
+          <!-- 6.1.5.b -->
+          <auc:SystemCategoryAffected>Lighting</auc:SystemCategoryAffected>
+          <auc:TechnologyCategories>
+            <auc:TechnologyCategory>
+              <auc:LightingImprovements>
+                <auc:MeasureName>Other</auc:MeasureName>
+              </auc:LightingImprovements>
+            </auc:TechnologyCategory>
+          </auc:TechnologyCategories>
+          <auc:MeasureScaleOfApplication>Individual system</auc:MeasureScaleOfApplication>
+          <!-- 6.1.5.a (only required if auc:TechnologyCategory/*/auc:MeasureName is Other) -->
+          <auc:CustomMeasureName>Update lighting schedules</auc:CustomMeasureName>
+          <!-- 6.1.5.a -->
+          <auc:LongDescription>The current lighting schedule is set to be at 80% output during weekdays, weekends, and holidays from 9am - 5pm.  This measure would implement a modified schedule to reduce default output to 40%, reducing scheduled on-period on weekends to 9am - 12pm, and having no required schedule on holidays.</auc:LongDescription>
+          <auc:UsefulLife>1</auc:UsefulLife>
+          <auc:MeasureInstallationCost>123</auc:MeasureInstallationCost>
+          <auc:MeasureMaterialCost>123</auc:MeasureMaterialCost>
+          <auc:Recommended>true</auc:Recommended>
+          <auc:StartDate>2020-01-01</auc:StartDate>
+          <auc:EndDate>2020-12-01</auc:EndDate>
+        </auc:Measure>
+        <!-- Capital measure -->
+        <auc:Measure ID="Measure-Capital-A">
+          <auc:TypeOfMeasure>
+            <auc:Replacements>
+              <auc:Replacement>
+                <auc:ExistingSystemReplaced IDref="Window-A-Original"/>
+                <auc:AlternativeSystemReplacement IDref="Window-A-New"/>
+              </auc:Replacement>
+            </auc:Replacements>
+          </auc:TypeOfMeasure>
+          <!-- 6.1.6.b -->
+          <auc:SystemCategoryAffected>Fenestration</auc:SystemCategoryAffected>
+          <auc:TechnologyCategories>
+            <auc:TechnologyCategory>
+              <auc:BuildingEnvelopeModifications>
+                <auc:MeasureName>Replace windows</auc:MeasureName>
+              </auc:BuildingEnvelopeModifications>
+            </auc:TechnologyCategory>
+          </auc:TechnologyCategories>
+          <auc:MeasureScaleOfApplication>Entire building</auc:MeasureScaleOfApplication>
+          <auc:UsefulLife>20</auc:UsefulLife>
+          <auc:MeasureInstallationCost>123</auc:MeasureInstallationCost>
+          <auc:MeasureMaterialCost>123</auc:MeasureMaterialCost>
+          <auc:Recommended>true</auc:Recommended>
+          <auc:StartDate>2020-01-01</auc:StartDate>
+          <auc:EndDate>2020-12-01</auc:EndDate>
+        </auc:Measure>
+      </auc:Measures>
+      <auc:Reports>
+        <auc:Report ID="Report-A">
+          <auc:Scenarios>
+            <auc:Scenario ID="Report-A-Scenario-A">
+              <!-- 6.1.2 (indicates this is measured data) -->
+              <auc:ScenarioType>
+                <auc:CurrentBuilding>
+                  <auc:CalculationMethod>
+                    <auc:Measured/>
+                  </auc:CalculationMethod>
+                </auc:CurrentBuilding>
+              </auc:ScenarioType>
+              <auc:ResourceUses>
+                <!-- 6.1.2 (covers multiple subsections) -->
+                <auc:ResourceUse ID="ResourceUse-Electricity">
+                  <auc:EnergyResource>Electricity</auc:EnergyResource>
+                  <auc:ResourceUseNotes>
+                    Sampling Methodology
+                    -------------------
+                    Notes on meter sampling methods (if sampling was used)
+
+                    Irregularities
+                    --------------
+                    Notes on any irregularities in meter readings
+                  </auc:ResourceUseNotes>
+                  <auc:ResourceUnits>kWh</auc:ResourceUnits>
+                  <auc:EndUse>All end uses</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>52943.01</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>180.65</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS1"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS2"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS3"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS4"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS5"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS6"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS7"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS8"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS9"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS10"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS11"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-TS12"/>
+                  </auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                  <auc:PeakResourceUnits>kW</auc:PeakResourceUnits>
+                  <auc:AnnualPeakNativeUnits>19.07</auc:AnnualPeakNativeUnits>
+                  <auc:AnnualFuelCost>5029.59</auc:AnnualFuelCost>
+                  <auc:UtilityIDs>
+                    <auc:UtilityID IDref="Utility-Electricity"/>
+                  </auc:UtilityIDs>
+                </auc:ResourceUse>
+                <auc:ResourceUse ID="ResourceUse-NG">
+                  <auc:EnergyResource>Natural gas</auc:EnergyResource>
+                  <auc:ResourceUseNotes>
+                    Sampling Methodology
+                    -------------------
+                    Notes on meter sampling methods (if sampling was used)
+
+                    Irregularities
+                    --------------
+                    Notes on any irregularities in meter readings
+                  </auc:ResourceUseNotes>
+                  <auc:ResourceUnits>MMBtu</auc:ResourceUnits>
+                  <auc:EndUse>All end uses</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>0.22</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>0.22</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS1"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS2"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS3"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS4"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS5"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS6"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS7"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS8"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS9"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS10"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS11"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-NG-TS12"/>
+                  </auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                  <auc:AnnualFuelCost>324</auc:AnnualFuelCost>
+                  <auc:UtilityIDs>
+                    <auc:UtilityID IDref="Utility-NG"/>
+                  </auc:UtilityIDs>
+                </auc:ResourceUse>
+                <auc:ResourceUse ID="ResourceUse-ElecGen">
+                  <auc:EnergyResource>Electricity-Onsite generated</auc:EnergyResource>
+                  <auc:ResourceUseNotes>
+                    Sampling Methodology
+                    -------------------
+                    Notes on meter sampling methods (if sampling was used)
+
+                    Irregularities
+                    --------------
+                    Notes on any irregularities in meter readings
+                  </auc:ResourceUseNotes>
+                  <auc:ResourceUnits>kWh</auc:ResourceUnits>
+                  <auc:EndUse>All end uses</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>5929</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>20.21</auc:AnnualFuelUseConsistentUnits>
+                  <auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS1"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS2"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS3"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS4"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS5"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS6"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS7"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS8"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS9"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS10"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS11"/>
+                    <auc:LinkedTimeSeriesID IDref="Scenario-A-ElecGen-TS12"/>
+                  </auc:AnnualFuelUseLinkedTimeSeriesIDs>
+                  <auc:AnnualFuelCost>543</auc:AnnualFuelCost>
+                  <auc:UtilityIDs>
+                    <auc:UtilityID IDref="Utility-ElecGen"/>
+                  </auc:UtilityIDs>
+                </auc:ResourceUse>
+                <!-- submeter examples -->
+                <auc:ResourceUse ID="ResourceUse-Electricity-Lighting-Submeter">
+                  <auc:EnergyResource>Electricity</auc:EnergyResource>
+                  <auc:EndUse>Total lighting</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>123</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>123</auc:AnnualFuelUseConsistentUnits>
+                  <auc:ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:ResourceUse>
+                <auc:ResourceUse ID="ResourceUse-Electricity-Heating-Submeter">
+                  <auc:EnergyResource>Electricity</auc:EnergyResource>
+                  <auc:EndUse>Heating</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>123</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>123</auc:AnnualFuelUseConsistentUnits>
+                  <auc:ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:ResourceUse>
+                <auc:ResourceUse ID="ResourceUse-Electricity-Cooling-Submeter">
+                  <auc:EnergyResource>Electricity</auc:EnergyResource>
+                  <auc:EndUse>Cooling</auc:EndUse>
+                  <auc:AnnualFuelUseNativeUnits>123</auc:AnnualFuelUseNativeUnits>
+                  <auc:AnnualFuelUseConsistentUnits>123</auc:AnnualFuelUseConsistentUnits>
+                  <auc:ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:ResourceUse>
+              </auc:ResourceUses>
+              <!-- 6.1.2 (total and peak monthly use - should exist for every resource use) -->
+              <!-- Analysis data based on DOE Small Office Prototype, ASHRAE 90.1-2010, Climate Zone 2A -->
+              <auc:TimeSeriesData>
+                <!-- Electricity TOTAL use -->
+                <auc:TimeSeries ID="Scenario-A-TS1">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4102.51</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS2">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>3737.04</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS3">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4167.07</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS4">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>3897.44</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS5">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4565.50</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS6">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4870.87</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS7">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4977.64</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS8">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>5275.05</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS9">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4788.79</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS10">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4353.99</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS11">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4154.67</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS12">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>4052.43</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <!-- Electricity PEAK use (required only when the ResourceUse is Electricity) -->
+                <auc:TimeSeries ID="Scenario-A-TS13">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>14.78</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS14">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>14.12</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS15">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>14.36</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS16">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>15.14</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS17">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>16.41</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS18">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>17.51</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS19">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>18.14</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS20">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>19.07</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS21">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>17.85</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS22">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>16.54</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS23">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>15.19</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS24">
+                  <auc:ReadingType>Peak</auc:ReadingType>
+                  <auc:PeakType>On-peak</auc:PeakType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>15.05</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <!-- Electricity COST (based on $0.095 / kWh) -->
+                <auc:TimeSeries ID="Scenario-A-TS25">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>389.74</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS26">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>355.02</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS27">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>395.87</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS28">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>370.26</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS29">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>433.72</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS30">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>462.73</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS31">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>472.88</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS32">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>501.13</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS33">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>454.94</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS34">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>413.63</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS35">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>394.69</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS36">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>384.98</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <!-- Electricity Load factor -->
+                <auc:TimeSeries ID="Scenario-A-TS37">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.373</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS38">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.394</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS39">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.390</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS40">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.358</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS41">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.374</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS42">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.386</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS43">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.369</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS44">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.372</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS45">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.373</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS46">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.354</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS47">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.380</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-TS48">
+                  <auc:ReadingType>Load factor</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.362</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-Electricity"/>
+                </auc:TimeSeries>
+                <!-- Natural Gas TOTAL use -->
+                <auc:TimeSeries ID="Scenario-A-NG-TS1">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.1</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS2">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.05</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS3">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.01</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS4">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS5">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS6">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS7">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS8">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS9">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS10">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS11">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS12">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>0.06</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <!-- Natural Gas COST (based on $27/month fixed & $0.4392/therm)-->
+                <auc:TimeSeries ID="Scenario-A-NG-TS13">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS14">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS15">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS16">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS17">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS18">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS19">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS20">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS21">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS22">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS23">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-NG-TS24">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>27</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-NG"/>
+                </auc:TimeSeries>
+                <!-- Electricity Generated TOTAL use -->
+                <!-- Generated using PVWatts -->
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS1">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>385</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS2">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>436</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS3">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>560</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS4">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>532</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS5">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>568</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS6">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>590</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS7">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>573</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS8">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>543</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS9">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>514</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS10">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>461</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS11">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>408</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS12">
+                  <auc:ReadingType>Total</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>359</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <!-- Electricity Generated COST -->
+                <!-- Generated using PVWatts -->
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS13">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-01-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-02-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>35</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS14">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-02-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-03-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>28</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>40</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS15">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-03-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-04-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>51</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS16">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-04-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-05-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>49</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS17">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-05-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-06-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>52</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS18">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-06-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-07-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>54</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS19">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-07-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-08-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>53</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS20">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-08-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-09-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>50</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS21">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-09-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-10-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>47</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS22">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-10-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-11-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>42</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS23">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-11-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2019-12-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>30</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>37</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+                <auc:TimeSeries ID="Scenario-A-ElecGen-TS24">
+                  <auc:ReadingType>Cost</auc:ReadingType>
+                  <auc:StartTimestamp>2019-12-01T00:00:00</auc:StartTimestamp>
+                  <auc:EndTimestamp>2020-01-01T00:00:00</auc:EndTimestamp>
+                  <auc:IntervalDuration>31</auc:IntervalDuration>
+                  <auc:IntervalDurationUnits>Day</auc:IntervalDurationUnits>
+                  <auc:IntervalFrequency>Month</auc:IntervalFrequency>
+                  <auc:IntervalReading>33</auc:IntervalReading>
+                  <auc:ResourceUseID IDref="ResourceUse-ElecGen"/>
+                </auc:TimeSeries>
+              </auc:TimeSeriesData>
+              <!-- 6.1.2.2 -->
+              <auc:AllResourceTotals>
+                <auc:AllResourceTotal ID="AllResourceTotal-A">
+                  <auc:SiteEnergyUse>170870</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>31.06</auc:SiteEnergyUseIntensity>
+                  <auc:BuildingEnergyUse>191080</auc:BuildingEnergyUse>
+                  <auc:BuildingEnergyUseIntensity>34.73</auc:BuildingEnergyUseIntensity>
+                  <auc:ImportedEnergyConsistentUnits>180.87</auc:ImportedEnergyConsistentUnits>
+                  <auc:OnsiteEnergyProductionConsistentUnits>20.21</auc:OnsiteEnergyProductionConsistentUnits>
+                  <auc:ExportedEnergyConsistentUnits>0</auc:ExportedEnergyConsistentUnits>
+                  <auc:NetIncreaseInStoredEnergyConsistentUnits>10</auc:NetIncreaseInStoredEnergyConsistentUnits>
+                  <auc:EnergyCost>5896.59</auc:EnergyCost>
+                  <auc:EnergyCostIndex>1.07</auc:EnergyCostIndex>
+                </auc:AllResourceTotal>
+              </auc:AllResourceTotals>
+              <auc:LinkedPremises>
+                <auc:Building>
+                  <auc:LinkedBuildingID IDref="Building-A"/>
+                </auc:Building>
+              </auc:LinkedPremises>
+            </auc:Scenario>
+            <!-- Target energy use -->
+            <!-- 6.1.4 -->
+            <auc:Scenario ID="Scenario-C">
+              <auc:ScenarioType>
+                <auc:Target>
+                  <auc:AnnualSavingsSiteEnergy>123</auc:AnnualSavingsSiteEnergy>
+                  <auc:AnnualSavingsCost>123</auc:AnnualSavingsCost>
+                </auc:Target>
+              </auc:ScenarioType>
+              <auc:AllResourceTotals>
+                <auc:AllResourceTotal ID="AllResourceTotal-C">
+                  <auc:SiteEnergyUse>123</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>123</auc:SiteEnergyUseIntensity>
+                  <auc:EnergyCost>123</auc:EnergyCost>
+                  <auc:EnergyCostIndex>123</auc:EnergyCostIndex>
+                </auc:AllResourceTotal>
+              </auc:AllResourceTotals>
+              <auc:LinkedPremises>
+                <auc:Building>
+                  <auc:LinkedBuildingID IDref="Building-A"/>
+                </auc:Building>
+              </auc:LinkedPremises>
+            </auc:Scenario>
+            <!-- Benchmark -->
+            <!-- 6.1.3 -->
+            <auc:Scenario ID="Scenario-D">
+              <auc:ScenarioType>
+                <auc:Benchmark>
+                  <auc:BenchmarkType>
+                    <auc:PortfolioManager/>
+                  </auc:BenchmarkType>
+                  <auc:BenchmarkTool>Portfolio Manager</auc:BenchmarkTool>
+                  <auc:BenchmarkYear>2020</auc:BenchmarkYear>
+                  <auc:BenchmarkValue>75</auc:BenchmarkValue>
+                </auc:Benchmark>
+              </auc:ScenarioType>
+              <auc:AllResourceTotals>
+                <auc:AllResourceTotal ID="AllResourceTotal-D">
+                  <auc:SiteEnergyUse>123</auc:SiteEnergyUse>
+                  <auc:SiteEnergyUseIntensity>123</auc:SiteEnergyUseIntensity>
+                </auc:AllResourceTotal>
+              </auc:AllResourceTotals>
+              <auc:LinkedPremises>
+                <auc:Building>
+                  <auc:LinkedBuildingID IDref="Building-A"/>
+                </auc:Building>
+              </auc:LinkedPremises>
+            </auc:Scenario>
+            <!-- Package of Measures -->
+            <!-- 6.1.4 -->
+            <auc:Scenario ID="Scenario-E">
+              <auc:ScenarioType>
+                <auc:PackageOfMeasures ID="PackageOfMeasures-LowCost">
+                  <auc:ReferenceCase IDref="Report-A-Scenario-A"/>
+                  <auc:MeasureIDs>
+                    <auc:MeasureID IDref="Measure-LowCost-A"/>
+                  </auc:MeasureIDs>
+                  <auc:CostCategory>Low-Cost or No-Cost</auc:CostCategory>
+                  <auc:AnnualSavingsSiteEnergy>123</auc:AnnualSavingsSiteEnergy>
+                  <auc:AnnualSavingsCost>123</auc:AnnualSavingsCost>
+                  <auc:AnnualSavingsByFuels>
+                    <auc:AnnualSavingsByFuel>
+                      <auc:EnergyResource>Electricity</auc:EnergyResource>
+                      <auc:ResourceUnits>kWh</auc:ResourceUnits>
+                      <auc:AnnualSavingsNativeUnits>123</auc:AnnualSavingsNativeUnits>
+                    </auc:AnnualSavingsByFuel>
+                    <auc:AnnualSavingsByFuel>
+                      <auc:EnergyResource>Natural gas</auc:EnergyResource>
+                      <auc:ResourceUnits>MMBtu</auc:ResourceUnits>
+                      <auc:AnnualSavingsNativeUnits>0</auc:AnnualSavingsNativeUnits>
+                    </auc:AnnualSavingsByFuel>
+                  </auc:AnnualSavingsByFuels>
+                  <auc:AnnualPeakElectricityReduction>123</auc:AnnualPeakElectricityReduction>
+                  <auc:AnnualDemandSavingsCost>123</auc:AnnualDemandSavingsCost>
+                  <auc:AnnualWaterSavings>123</auc:AnnualWaterSavings>
+                  <auc:AnnualWaterCostSavings>123</auc:AnnualWaterCostSavings>
+                  <auc:ImplementationPeriod>1</auc:ImplementationPeriod>
+                  <auc:PackageFirstCost>123</auc:PackageFirstCost>
+                  <auc:MVCost>123</auc:MVCost>
+                  <auc:OMCostAnnualSavings>123</auc:OMCostAnnualSavings>
+                  <auc:EquipmentDisposalAndSalvageCosts>123</auc:EquipmentDisposalAndSalvageCosts>
+                  <auc:ImplementationPeriodCostSavings>123</auc:ImplementationPeriodCostSavings>
+                  <auc:ProjectMarkup>123</auc:ProjectMarkup>
+                  <auc:FundingFromIncentives>123</auc:FundingFromIncentives>
+                  <auc:FundingFromTaxCredits>123</auc:FundingFromTaxCredits>
+                  <auc:OtherFinancialIncentives>123</auc:OtherFinancialIncentives>
+                  <auc:RecurringIncentives>123</auc:RecurringIncentives>
+                  <auc:SimplePayback>123</auc:SimplePayback>
+                  <auc:InternalRateOfReturn>123</auc:InternalRateOfReturn>
+                </auc:PackageOfMeasures>
+              </auc:ScenarioType>
+              <auc:LinkedPremises>
+                <auc:Building>
+                  <auc:LinkedBuildingID IDref="Building-A"/>
+                </auc:Building>
+              </auc:LinkedPremises>
+            </auc:Scenario>
+          </auc:Scenarios>
+          <!-- 6.1.2.1.a -->
+          <auc:Utilities>
+            <auc:Utility ID="Utility-Electricity">
+              <!-- 6.1.2.1.c -->
+              <auc:RateSchedules>
+                <auc:RateSchedule ID="RateSchedule-A">
+                  <auc:TypeOfRateStructure>
+                    <auc:FlatRate>
+                      <auc:RatePeriods>
+                        <auc:RatePeriod>
+                          <auc:ApplicableStartDateForEnergyRate>--01-01</auc:ApplicableStartDateForEnergyRate>
+                          <auc:ApplicableEndDateForEnergyRate>--12-01</auc:ApplicableEndDateForEnergyRate>
+                          <auc:ApplicableStartDateForDemandRate>--01-01</auc:ApplicableStartDateForDemandRate>
+                          <auc:ApplicableEndDateForDemandRate>--12-01</auc:ApplicableEndDateForDemandRate>
+                          <auc:EnergyCostRate>123</auc:EnergyCostRate>
+                          <auc:ElectricDemandRate>123</auc:ElectricDemandRate>
+                        </auc:RatePeriod>
+                      </auc:RatePeriods>
+                    </auc:FlatRate>
+                  </auc:TypeOfRateStructure>
+                </auc:RateSchedule>
+              </auc:RateSchedules>
+              <auc:UtilityMeterNumbers>
+                <auc:UtilityMeterNumber>12345</auc:UtilityMeterNumber>
+              </auc:UtilityMeterNumbers>
+              <!-- 6.1.2.1.b -->
+              <auc:UtilityAccountNumber>12345</auc:UtilityAccountNumber>
+              <auc:UtilityBillpayer>Building Owner</auc:UtilityBillpayer>
+            </auc:Utility>
+            <auc:Utility ID="Utility-NG">
+              <!-- 6.1.2.1.c -->
+              <auc:RateSchedules>
+                <auc:RateSchedule ID="RateSchedule-B">
+                  <auc:TypeOfRateStructure>
+                    <auc:TimeOfUseRate>
+                      <auc:RatePeriods>
+                        <auc:RatePeriod>
+                          <auc:ApplicableStartDateForEnergyRate>--01-01</auc:ApplicableStartDateForEnergyRate>
+                          <auc:ApplicableEndDateForEnergyRate>--12-01</auc:ApplicableEndDateForEnergyRate>
+                          <auc:TimeOfUsePeriods>
+                            <auc:TimeOfUsePeriod>
+                              <auc:ApplicableStartTimeForEnergyRate>00:00:00</auc:ApplicableStartTimeForEnergyRate>
+                              <auc:ApplicableEndTimeForEnergyRate>12:00:00</auc:ApplicableEndTimeForEnergyRate>
+                              <auc:EnergyCostRate>123</auc:EnergyCostRate>
+                            </auc:TimeOfUsePeriod>
+                            <auc:TimeOfUsePeriod>
+                              <auc:ApplicableStartTimeForEnergyRate>12:00:00</auc:ApplicableStartTimeForEnergyRate>
+                              <auc:ApplicableEndTimeForEnergyRate>24:00:00</auc:ApplicableEndTimeForEnergyRate>
+                              <auc:EnergyCostRate>123</auc:EnergyCostRate>
+                            </auc:TimeOfUsePeriod>
+                          </auc:TimeOfUsePeriods>
+                        </auc:RatePeriod>
+                      </auc:RatePeriods>
+                    </auc:TimeOfUseRate>
+                  </auc:TypeOfRateStructure>
+                </auc:RateSchedule>
+              </auc:RateSchedules>
+              <auc:UtilityMeterNumbers>
+                <auc:UtilityMeterNumber>12345</auc:UtilityMeterNumber>
+              </auc:UtilityMeterNumbers>
+              <!-- 6.1.2.1.b -->
+              <auc:UtilityAccountNumber>12345</auc:UtilityAccountNumber>
+              <auc:UtilityBillpayer>Building Owner</auc:UtilityBillpayer>
+            </auc:Utility>
+            <auc:Utility ID="Utility-ElecGen">
+              <!-- 6.1.2.1.c -->
+              <auc:RateSchedules>
+                <auc:RateSchedule ID="RateSchedule-C">
+                  <auc:TypeOfRateStructure>
+                    <auc:TieredRates>
+                      <auc:TieredRate>
+                        <auc:RatePeriods>
+                          <auc:RatePeriod>
+                            <auc:ApplicableStartDateForEnergyRate>--01-01</auc:ApplicableStartDateForEnergyRate>
+                            <auc:ApplicableEndDateForEnergyRate>--12-01</auc:ApplicableEndDateForEnergyRate>
+                            <auc:ApplicableStartDateForDemandRate>--01-01</auc:ApplicableStartDateForDemandRate>
+                            <auc:ApplicableEndDateForDemandRate>--12-01</auc:ApplicableEndDateForDemandRate>
+                            <auc:RateTiers>
+                              <auc:RateTier>
+                                <auc:MaxkWhUsage>123</auc:MaxkWhUsage>
+                                <auc:EnergyCostRate>123</auc:EnergyCostRate>
+                              </auc:RateTier>
+                              <auc:RateTier>
+                                <auc:MaxkWhUsage>123</auc:MaxkWhUsage>
+                                <auc:EnergyCostRate>123</auc:EnergyCostRate>
+                              </auc:RateTier>
+                            </auc:RateTiers>
+                          </auc:RatePeriod>
+                        </auc:RatePeriods>
+                      </auc:TieredRate>
+                    </auc:TieredRates>
+                  </auc:TypeOfRateStructure>
+                </auc:RateSchedule>
+              </auc:RateSchedules>
+              <auc:UtilityMeterNumbers>
+                <auc:UtilityMeterNumber>12345</auc:UtilityMeterNumber>
+              </auc:UtilityMeterNumbers>
+              <!-- 6.1.2.1.b -->
+              <auc:UtilityAccountNumber>12345</auc:UtilityAccountNumber>
+              <auc:UtilityBillpayer>Building Owner</auc:UtilityBillpayer>
+            </auc:Utility>
+          </auc:Utilities>
+          <auc:AuditorContactID IDref="Contact-B"/>
+        </auc:Report>
+      </auc:Reports>
+      <auc:Contacts>
+        <!-- 6.1.1.1.b and 6.1.1.1.c -->
+        <auc:Contact ID="Contact-A">
+          <auc:ContactRoles>
+            <auc:ContactRole>Owner</auc:ContactRole>
+          </auc:ContactRoles>
+          <auc:ContactName>Building Owner</auc:ContactName>
+          <auc:ContactCompany>Owner Company</auc:ContactCompany>
+          <!-- <auc:Address></auc:Address> -->
+          <!-- recommended -->
+          <auc:ContactTelephoneNumbers>
+            <auc:ContactTelephoneNumber>
+              <auc:TelephoneNumber>123-456-7890</auc:TelephoneNumber>
+            </auc:ContactTelephoneNumber>
+          </auc:ContactTelephoneNumbers>
+          <!-- recommended -->
+          <auc:ContactEmailAddresses>
+            <auc:ContactEmailAddress>
+              <auc:EmailAddress>owner@example.com</auc:EmailAddress>
+            </auc:ContactEmailAddress>
+          </auc:ContactEmailAddresses>
+        </auc:Contact>
+        <!-- 6.1.1.1.c -->
+        <auc:Contact ID="Contact-B">
+          <auc:ContactRoles>
+            <auc:ContactRole>Energy Auditor</auc:ContactRole>
+          </auc:ContactRoles>
+          <auc:ContactName>Building Auditor</auc:ContactName>
+          <auc:ContactCompany>Auditor Company</auc:ContactCompany>
+          <!-- <auc:Address></auc:Address> -->
+          <!-- recommended -->
+          <auc:ContactTelephoneNumbers>
+            <auc:ContactTelephoneNumber>
+              <auc:TelephoneNumber>123-456-7890</auc:TelephoneNumber>
+            </auc:ContactTelephoneNumber>
+          </auc:ContactTelephoneNumbers>
+          <!-- recommended -->
+          <auc:ContactEmailAddresses>
+            <auc:ContactEmailAddress>
+              <auc:EmailAddress>auditor@example.com</auc:EmailAddress>
+            </auc:ContactEmailAddress>
+          </auc:ContactEmailAddresses>
+        </auc:Contact>
+      </auc:Contacts>
+    </auc:Facility>
+  </auc:Facilities>
+</auc:BuildingSync>

--- a/spec/files/v2.4.0/example-smalloffice-level1.xml
+++ b/spec/files/v2.4.0/example-smalloffice-level1.xml
@@ -1,0 +1,1133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../../../BuildingSync.xsd"
+  version="2.5.0">
+  <Facilities>
+    <Facility ID="Facility-1">
+      <Sites>
+        <Site ID="Site-1">
+          <Buildings>
+            <Building ID="Building-Small-Office-Prototype">
+              <PremisesName>Small Office Prototype</PremisesName>
+              <PremisesNotes>Here we record general problems / issues identified in a walkthrough survey.</PremisesNotes>
+              <Address>
+                <StreetAddressDetail>
+                  <Simplified>
+                    <StreetAddress>4055 Brooks Street</StreetAddress>
+                  </Simplified>
+                </StreetAddressDetail>
+                <City>Missoula</City>
+                <State>MT</State>
+                <PostalCode>59804</PostalCode>
+              </Address>
+              <BuildingClassification>Commercial</BuildingClassification>
+              <OccupancyClassification>Office</OccupancyClassification>
+              <PrimaryContactID IDref="Contact-Owner"/>
+              <FloorsAboveGrade>1</FloorsAboveGrade>
+              <FloorsBelowGrade>0</FloorsBelowGrade>
+              <ConditionedFloorsAboveGrade>1</ConditionedFloorsAboveGrade>
+              <ConditionedFloorsBelowGrade>0</ConditionedFloorsBelowGrade>
+              <HistoricalLandmark>false</HistoricalLandmark>
+              <FloorAreas>
+                <FloorArea>
+                  <FloorAreaType>Gross</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                </FloorArea>
+                <FloorArea>
+                  <FloorAreaType>Conditioned</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                </FloorArea>
+              </FloorAreas>
+              <YearOfConstruction>2006</YearOfConstruction>
+              <YearOccupied>2006</YearOccupied>
+              <YearOfLastMajorRemodel>2006</YearOfLastMajorRemodel>
+              <Sections>
+                <Section ID="Section-1">
+                  <SectionType>Space function</SectionType>
+                  <OccupancyClassification>Office</OccupancyClassification>
+                  <OriginalOccupancyClassification>Office</OriginalOccupancyClassification>
+                  <OccupancyLevels>
+                    <OccupancyLevel>
+                      <OccupantQuantityType>Peak total occupants</OccupantQuantityType>
+                      <OccupantQuantity>31.000000</OccupantQuantity>
+                    </OccupancyLevel>
+                  </OccupancyLevels>
+                  <TypicalOccupantUsages>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>40.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Hours per week</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>50.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Weeks per year</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                  </TypicalOccupantUsages>
+                  <FloorAreas>
+                    <FloorArea>
+                      <FloorAreaType>Gross</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                    <FloorArea>
+                      <FloorAreaType>Conditioned</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                  </FloorAreas>
+                </Section>
+              </Sections>
+            </Building>
+          </Buildings>
+        </Site>
+      </Sites>
+      <Systems>
+        <HVACSystems>
+          <HVACSystem ID="HVACSystem-1">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-2">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-3">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-4">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-5">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+        </HVACSystems>
+        <LightingSystems>
+          <LightingSystem ID="LightingSystem-1">
+            <LampType>
+              <LinearFluorescent>
+                <LampLabel>T8</LampLabel>
+              </LinearFluorescent>
+            </LampType>
+            <BallastType>Standard Electronic</BallastType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </LightingSystem>
+        </LightingSystems>
+        <PlugLoads>
+          <PlugLoad ID="PlugLoad-1">
+            <WeightedAverageLoad>0.630000</WeightedAverageLoad>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </PlugLoad>
+        </PlugLoads>
+      </Systems>
+      <Measures>
+        <Measure ID="Measure-LEDs">
+          <TypeOfMeasure>
+            <Replacements>
+              <Replacement>
+                <ExistingSystemReplaced IDref="LightingSystem-1"/>
+              </Replacement>
+            </Replacements>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Lighting</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <LightingImprovements>
+                <MeasureName>Retrofit with light emitting diode technologies</MeasureName>
+              </LightingImprovements>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <LongDescription>This measure is designed to replace all fluorescent bulbs with LEDs</LongDescription>
+        </Measure>
+        <Measure ID="Measure-VSDs">
+          <TypeOfMeasure>
+            <ModificationRetrocommissions>
+              <ModificationRetrocommissioning>
+                <ExistingSystemAffected IDref="HVACSystem-1"/>
+                <ExistingSystemAffected IDref="HVACSystem-2"/>
+                <ExistingSystemAffected IDref="HVACSystem-3"/>
+                <ExistingSystemAffected IDref="HVACSystem-4"/>
+                <ExistingSystemAffected IDref="HVACSystem-5"/>
+              </ModificationRetrocommissioning>
+            </ModificationRetrocommissions>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Fan</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <OtherElectricMotorsAndDrives>
+                <MeasureName>Add VSD motor controller</MeasureName>
+              </OtherElectricMotorsAndDrives>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <LongDescription>This measure is designed to retrofit all RTU fans with a VSD</LongDescription>
+        </Measure>
+      </Measures>
+      <Reports>
+        <Report ID="Report-L1-Audit">
+          <Scenarios>
+            <Scenario ID="Scenario-1">
+              <ScenarioType>
+                <CurrentBuilding>
+                  <CalculationMethod>
+                    <Measured/>
+                  </CalculationMethod>
+                </CurrentBuilding>
+              </ScenarioType>
+              <ResourceUses>
+                <ResourceUse ID="ResourceUse-Electricity">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUseNotes>This is required for L1 to document irregularities in monthly energy patterns (Std 211 6.1.2.1.j). No irregularities found.</ResourceUseNotes>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>68516.730000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>234.000000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <PeakResourceUnits>kW</PeakResourceUnits>
+                  <AnnualPeakNativeUnits>21.120000</AnnualPeakNativeUnits>
+                  <AnnualPeakConsistentUnits>21.120000</AnnualPeakConsistentUnits>
+                  <AnnualFuelCost>5304.000000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Electric"/>
+                  </UtilityIDs>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-GreenhouseGasEmissions">
+                  <Emissions>
+                    <Emission>
+                      <EmissionBoundary>Indirect</EmissionBoundary>
+                      <EmissionsType>CO2e</EmissionsType>
+                      <GHGEmissions>25000.000000</GHGEmissions>
+                      <EmissionsLinkedTimeSeriesIDs>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-1"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-2"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-3"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-4"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-5"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-6"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-7"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-8"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-9"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-10"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-11"/>
+                        <EmissionsLinkedTimeSeriesID IDref="TS-ResourceUse-GreenhouseGasEmissions-12"/>
+                      </EmissionsLinkedTimeSeriesIDs>
+                    </Emission>
+                  </Emissions>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Natural-gas">
+                  <EnergyResource>Natural gas</EnergyResource>
+                  <ResourceUseNotes>No irregularities in monthly energy consumption found.</ResourceUseNotes>
+                  <ResourceUnits>MMBtu</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>17.160000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>17.160000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <AnnualFuelCost>91.630000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Natural-Gas"/>
+                  </UtilityIDs>
+                </ResourceUse>
+              </ResourceUses>
+              <TimeSeriesData>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6792.890000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5841.750000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6025.190000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4985.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5184.040000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5358.550000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5755.670000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5981.780000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5401.940000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5225.840000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5672.150000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6291.630000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>240.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>230.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>280.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>270.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>240.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-GreenhouseGasEmissions-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Greenhouse Gas Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-GreenhouseGasEmissions"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5.700000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.580000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.400000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.020000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.360000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6.080000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-1">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>15.420000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-2">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>15.500000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-3">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.250000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-4">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.650000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-5">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>18.560000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-6">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-7">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.820000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-8">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.120000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-9">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.420000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-10">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.080000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-11">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>17.400000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-12">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>520.480000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>451.530000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>464.830000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>389.430000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>403.840000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>416.490000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>445.290000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>461.680000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>419.640000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>406.870000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>439.230000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>484.140000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>30.440000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.410000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>3.100000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>2.140000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.110000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.050000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>1.920000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>32.470000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+              </TimeSeriesData>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-1">
+                  <SiteEnergyUse>250953.500000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>45.600000</SiteEnergyUseIntensity>
+                  <SourceEnergyUse>759011.900000</SourceEnergyUse>
+                  <SourceEnergyUseIntensity>138.000000</SourceEnergyUseIntensity>
+                  <BuildingEnergyUse>250953.500000</BuildingEnergyUse>
+                  <BuildingEnergyUseIntensity>45.600000</BuildingEnergyUseIntensity>
+                  <ImportedEnergyConsistentUnits>250.953500</ImportedEnergyConsistentUnits>
+                  <OnsiteEnergyProductionConsistentUnits>0.000000</OnsiteEnergyProductionConsistentUnits>
+                  <ExportedEnergyConsistentUnits>0.000000</ExportedEnergyConsistentUnits>
+                  <NetIncreaseInStoredEnergyConsistentUnits>0.000000</NetIncreaseInStoredEnergyConsistentUnits>
+                  <EnergyCost>5395.000000</EnergyCost>
+                  <EnergyCostIndex>0.980000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+            </Scenario>
+            <Scenario ID="Scenario-Benchmark">
+              <ScenarioType>
+                <Benchmark>
+                  <BenchmarkType>
+                    <PortfolioManager>
+                      <PMBenchmarkDate>2021-03-24</PMBenchmarkDate>
+                    </PortfolioManager>
+                  </BenchmarkType>
+                  <BenchmarkTool>Portfolio Manager</BenchmarkTool>
+                  <BenchmarkYear>2019</BenchmarkYear>
+                  <BenchmarkValue>56.000000</BenchmarkValue>
+                </Benchmark>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Benchmark">
+                  <SiteEnergyUse>274825.000000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>50.000000</SiteEnergyUseIntensity>
+                </AllResourceTotal>
+              </AllResourceTotals>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-Target">
+              <ScenarioType>
+                <Target>
+                  <ReferenceCase IDref="Scenario-Benchmark"/>
+                  <AnnualSavingsSiteEnergy>67181.500000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>931</AnnualSavingsCost>
+                  <ENERGYSTARScore>70.000000</ENERGYSTARScore>
+                </Target>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Target">
+                  <SiteEnergyUse>207643.500000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>37.800000</SiteEnergyUseIntensity>
+                  <EnergyCost>4451.510000</EnergyCost>
+                  <EnergyCostIndex>0.810000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+            <Scenario ID="Scenario-POM-VSDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-VSDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs-VSDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs-VSDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+          </Scenarios>
+          <Utilities>
+            <Utility ID="Utility-Electric">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Electricity">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--01-01</ApplicableEndDateForEnergyRate>
+                          <ApplicableStartDateForDemandRate>--01-01</ApplicableStartDateForDemandRate>
+                          <ApplicableEndDateForDemandRate>--01-01</ApplicableEndDateForDemandRate>
+                          <EnergyCostRate>0.072500</EnergyCostRate>
+                          <ElectricDemandRate>0.000000</ElectricDemandRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://missoulaelectric.com/member-care/billing-payment/rates/</ReferenceForRateStructure>
+                  <FixedMonthlyCharge>28.000000</FixedMonthlyCharge>
+                </RateSchedule>
+              </RateSchedules>
+              <EIAUtilityID>12692</EIAUtilityID>
+              <UtilityName>Missoula Electric Cooperative</UtilityName>
+              <UtilityAccountNumber>some-account-number</UtilityAccountNumber>
+            </Utility>
+            <Utility ID="Utility-Natural-Gas">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Natural-Gas">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--01-01</ApplicableEndDateForEnergyRate>
+                          <EnergyCostRate>5.500000</EnergyCostRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://naturalgaslocal.com/states/montana/missoula/</ReferenceForRateStructure>
+                </RateSchedule>
+              </RateSchedules>
+              <UtilityName>NorthWestern Energy</UtilityName>
+              <UtilityAccountNumber>some-other-account-number</UtilityAccountNumber>
+            </Utility>
+          </Utilities>
+          <AuditorContactID IDref="Contact-Auditor"/>
+          <LinkedPremisesOrSystem>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremisesOrSystem>
+        </Report>
+      </Reports>
+      <Contacts>
+        <Contact ID="Contact-Owner">
+          <ContactRoles>
+            <ContactRole>Owner</ContactRole>
+          </ContactRoles>
+          <ContactName>The dude</ContactName>
+          <ContactCompany>Some big company</ContactCompany>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.dude@somebigco.net</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+        <Contact ID="Contact-Auditor">
+          <ContactRoles>
+            <ContactRole>Energy Auditor</ContactRole>
+          </ContactRoles>
+          <ContactName>The lady</ContactName>
+          <ContactCompany>Auditeers</ContactCompany>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.lady@the-three-auditeers.com</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+      </Contacts>
+    </Facility>
+  </Facilities>
+</BuildingSync>

--- a/spec/files/v2.4.0/example-smalloffice-level2.xml
+++ b/spec/files/v2.4.0/example-smalloffice-level2.xml
@@ -1,0 +1,2733 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../../../BuildingSync.xsd"
+  version="2.5.0">
+  <Facilities>
+    <Facility ID="Facility-1">
+      <Sites>
+        <Site ID="Site-1">
+          <Buildings>
+            <Building ID="Building-Small-Office-Prototype">
+              <PremisesName>Prototype Small Office in Denver</PremisesName>
+              <PremisesNotes>Here we record general problems / issues identified in a walkthrough survey.</PremisesNotes>
+              <PremisesIdentifiers>
+                <PremisesIdentifier>
+                  <IdentifierCustomName>City Custom Building ID</IdentifierCustomName>
+                  <IdentifierValue>some ID</IdentifierValue>
+                </PremisesIdentifier>
+                <PremisesIdentifier>
+                  <IdentifierCustomName>Custom ID 1</IdentifierCustomName>
+                  <IdentifierValue>some other ID</IdentifierValue>
+                </PremisesIdentifier>
+              </PremisesIdentifiers>
+              <Address>
+                <StreetAddressDetail>
+                  <Simplified>
+                    <StreetAddress>Some address</StreetAddress>
+                  </Simplified>
+                </StreetAddressDetail>
+                <City>Denver</City>
+                <State>CO</State>
+                <PostalCode>80014</PostalCode>
+              </Address>
+              <Longitude>-104.830000</Longitude>
+              <Latitude>39.660000</Latitude>
+              <BuildingClassification>Commercial</BuildingClassification>
+              <OccupancyClassification>Office</OccupancyClassification>
+              <PrimaryContactID IDref="Contact-Owner"/>
+              <FloorsAboveGrade>1</FloorsAboveGrade>
+              <FloorsBelowGrade>0</FloorsBelowGrade>
+              <ConditionedFloorsAboveGrade>1</ConditionedFloorsAboveGrade>
+              <ConditionedFloorsBelowGrade>0</ConditionedFloorsBelowGrade>
+              <BuildingAutomationSystem>true</BuildingAutomationSystem>
+              <HistoricalLandmark>false</HistoricalLandmark>
+              <FloorAreas>
+                <FloorArea>
+                  <FloorAreaType>Gross</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                  <ExcludedSectionIDs>
+                    <ExcludedSectionID IDref="Section-excluded"/>
+                  </ExcludedSectionIDs>
+                </FloorArea>
+                <FloorArea>
+                  <FloorAreaType>Conditioned</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                  <ExcludedSectionIDs>
+                    <ExcludedSectionID IDref="Section-excluded"/>
+                  </ExcludedSectionIDs>
+                </FloorArea>
+              </FloorAreas>
+              <TotalExteriorAboveGradeWallArea>6500.000000</TotalExteriorAboveGradeWallArea>
+              <TotalExteriorBelowGradeWallArea>0.000000</TotalExteriorBelowGradeWallArea>
+              <OverallWindowToWallRatio>0.213300</OverallWindowToWallRatio>
+              <OverallDoorToWallRatio>0.050000</OverallDoorToWallRatio>
+              <YearOfConstruction>2000</YearOfConstruction>
+              <YearOccupied>2000</YearOccupied>
+              <YearOfLastEnergyAudit>2010</YearOfLastEnergyAudit>
+              <RetrocommissioningDate>2020-03-01</RetrocommissioningDate>
+              <YearOfLastMajorRemodel>2000</YearOfLastMajorRemodel>
+              <Sections>
+                <Section ID="Section-office">
+                  <SectionType>Space function</SectionType>
+                  <OccupancyClassification>Office</OccupancyClassification>
+                  <OriginalOccupancyClassification>Office</OriginalOccupancyClassification>
+                  <OccupancyLevels>
+                    <OccupancyLevel>
+                      <OccupantQuantityType>Peak total occupants</OccupantQuantityType>
+                      <OccupantQuantity>31.000000</OccupantQuantity>
+                    </OccupancyLevel>
+                  </OccupancyLevels>
+                  <TypicalOccupantUsages>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>40.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Hours per week</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>50.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Weeks per year</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                  </TypicalOccupantUsages>
+                  <FloorAreas>
+                    <FloorArea>
+                      <FloorAreaType>Gross</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                    <FloorArea>
+                      <FloorAreaType>Conditioned</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                  </FloorAreas>
+                  <ThermalZoneLayout>Single zone</ThermalZoneLayout>
+                </Section>
+                <Section ID="Section-Whole-building">
+                  <SectionType>Whole building</SectionType>
+                  <FootprintShape>Rectangular</FootprintShape>
+                  <Sides>
+                    <Side>
+                      <SideNumber>A1</SideNumber>
+                      <WallIDs>
+                        <WallID IDref="Wall-1">
+                          <WallArea>909.012230</WallArea>
+                        </WallID>
+                      </WallIDs>
+                      <WindowIDs>
+                        <WindowID IDref="Window-1-Original">
+                          <FenestrationArea>180.187860</FenestrationArea>
+                        </WindowID>
+                      </WindowIDs>
+                      <DoorIDs>
+                        <DoorID IDref="Door-1">
+                          <FenestrationArea>42.086890</FenestrationArea>
+                        </DoorID>
+                      </DoorIDs>
+                    </Side>
+                    <Side>
+                      <SideNumber>B1</SideNumber>
+                      <WallIDs>
+                        <WallID IDref="Wall-1">
+                          <WallArea>606.008200</WallArea>
+                        </WallID>
+                      </WallIDs>
+                      <WindowIDs>
+                        <WindowID IDref="Window-1-Original">
+                          <FenestrationArea>120.125240</FenestrationArea>
+                        </WindowID>
+                      </WindowIDs>
+                      <DoorIDs>
+                        <DoorID IDref="Door-1">
+                          <FenestrationArea>0.000000</FenestrationArea>
+                        </DoorID>
+                      </DoorIDs>
+                    </Side>
+                    <Side>
+                      <SideNumber>C1</SideNumber>
+                      <WallIDs>
+                        <WallID IDref="Wall-1">
+                          <WallArea>909.012230</WallArea>
+                        </WallID>
+                      </WallIDs>
+                      <WindowIDs>
+                        <WindowID IDref="Window-1-Original">
+                          <FenestrationArea>180.187860</FenestrationArea>
+                        </WindowID>
+                      </WindowIDs>
+                      <DoorIDs>
+                        <DoorID IDref="Door-1">
+                          <FenestrationArea>0.000000</FenestrationArea>
+                        </DoorID>
+                      </DoorIDs>
+                    </Side>
+                    <Side>
+                      <SideNumber>D1</SideNumber>
+                      <WallIDs>
+                        <WallID IDref="Wall-1">
+                          <WallArea>606.008200</WallArea>
+                        </WallID>
+                      </WallIDs>
+                      <WindowIDs>
+                        <WindowID IDref="Window-1-Original">
+                          <FenestrationArea>120.125240</FenestrationArea>
+                        </WindowID>
+                      </WindowIDs>
+                      <DoorIDs>
+                        <DoorID IDref="Door-1">
+                          <FenestrationArea>0.000000</FenestrationArea>
+                        </DoorID>
+                      </DoorIDs>
+                    </Side>
+                  </Sides>
+                  <Roofs>
+                    <Roof>
+                      <RoofID IDref="Roof-1">
+                        <RoofArea>6444.999000</RoofArea>
+                        <RoofCondition>Good</RoofCondition>
+                      </RoofID>
+                    </Roof>
+                  </Roofs>
+                  <Foundations>
+                    <Foundation>
+                      <FoundationID IDref="Foundation-1">
+                        <FoundationArea>3891.153600</FoundationArea>
+                      </FoundationID>
+                    </Foundation>
+                  </Foundations>
+                </Section>
+                <Section ID="Section-excluded"/>
+              </Sections>
+            </Building>
+          </Buildings>
+        </Site>
+      </Sites>
+      <Systems>
+        <HVACSystems>
+          <HVACSystem ID="HVACSystem-1">
+            <HeatingAndCoolingSystems>
+              <ZoningSystemType>Single zone</ZoningSystemType>
+              <HeatingSources>
+                <HeatingSource ID="HeatingSource-1">
+                  <HeatingSourceType>
+                    <HeatPump>
+                      <HeatPumpType>Packaged Unitary</HeatPumpType>
+                      <HeatPumpBackupSystemFuel>Natural gas</HeatPumpBackupSystemFuel>
+                      <HeatPumpBackupAFUE>0.000000</HeatPumpBackupAFUE>
+                      <CoolingSourceID IDref="CoolingSource-1"/>
+                    </HeatPump>
+                  </HeatingSourceType>
+                  <AnnualHeatingEfficiencyValue>3.010000</AnnualHeatingEfficiencyValue>
+                  <AnnualHeatingEfficiencyUnits>COP</AnnualHeatingEfficiencyUnits>
+                  <InputCapacity>10311.100000</InputCapacity>
+                  <Capacity>10311.100000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <HeatingSourceCondition>Good</HeatingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </HeatingSource>
+                <HeatingSource ID="HeatingSource-2">
+                  <HeatingSourceType>
+                    <HeatPump>
+                      <HeatPumpType>Packaged Unitary</HeatPumpType>
+                      <HeatPumpBackupSystemFuel>Natural gas</HeatPumpBackupSystemFuel>
+                      <HeatPumpBackupAFUE>0.000000</HeatPumpBackupAFUE>
+                      <CoolingSourceID IDref="CoolingSource-2"/>
+                    </HeatPump>
+                  </HeatingSourceType>
+                  <AnnualHeatingEfficiencyValue>3.010000</AnnualHeatingEfficiencyValue>
+                  <AnnualHeatingEfficiencyUnits>COP</AnnualHeatingEfficiencyUnits>
+                  <InputCapacity>9801.300000</InputCapacity>
+                  <Capacity>9801.300000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <HeatingSourceCondition>Good</HeatingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </HeatingSource>
+                <HeatingSource ID="HeatingSource-3">
+                  <HeatingSourceType>
+                    <HeatPump>
+                      <HeatPumpType>Packaged Unitary</HeatPumpType>
+                      <HeatPumpBackupSystemFuel>Natural gas</HeatPumpBackupSystemFuel>
+                      <HeatPumpBackupAFUE>0.000000</HeatPumpBackupAFUE>
+                      <CoolingSourceID IDref="CoolingSource-3"/>
+                    </HeatPump>
+                  </HeatingSourceType>
+                  <AnnualHeatingEfficiencyValue>3.010000</AnnualHeatingEfficiencyValue>
+                  <AnnualHeatingEfficiencyUnits>COP</AnnualHeatingEfficiencyUnits>
+                  <InputCapacity>7858.100000</InputCapacity>
+                  <Capacity>7858.100000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <HeatingSourceCondition>Good</HeatingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </HeatingSource>
+                <HeatingSource ID="HeatingSource-4">
+                  <HeatingSourceType>
+                    <HeatPump>
+                      <HeatPumpType>Packaged Unitary</HeatPumpType>
+                      <HeatPumpBackupSystemFuel>Natural gas</HeatPumpBackupSystemFuel>
+                      <HeatPumpBackupAFUE>0.000000</HeatPumpBackupAFUE>
+                      <CoolingSourceID IDref="CoolingSource-4"/>
+                    </HeatPump>
+                  </HeatingSourceType>
+                  <AnnualHeatingEfficiencyValue>3.010000</AnnualHeatingEfficiencyValue>
+                  <AnnualHeatingEfficiencyUnits>COP</AnnualHeatingEfficiencyUnits>
+                  <InputCapacity>9067.800000</InputCapacity>
+                  <Capacity>9067.800000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <HeatingSourceCondition>Good</HeatingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </HeatingSource>
+                <HeatingSource ID="HeatingSource-5">
+                  <HeatingSourceType>
+                    <HeatPump>
+                      <HeatPumpType>Packaged Unitary</HeatPumpType>
+                      <HeatPumpBackupSystemFuel>Natural gas</HeatPumpBackupSystemFuel>
+                      <HeatPumpBackupAFUE>0.000000</HeatPumpBackupAFUE>
+                      <CoolingSourceID IDref="CoolingSource-5"/>
+                    </HeatPump>
+                  </HeatingSourceType>
+                  <AnnualHeatingEfficiencyValue>3.010000</AnnualHeatingEfficiencyValue>
+                  <AnnualHeatingEfficiencyUnits>COP</AnnualHeatingEfficiencyUnits>
+                  <InputCapacity>9855.400000</InputCapacity>
+                  <Capacity>9855.400000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <HeatingSourceCondition>Good</HeatingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </HeatingSource>
+              </HeatingSources>
+              <CoolingSources>
+                <CoolingSource ID="CoolingSource-1">
+                  <CoolingSourceType>
+                    <DX>
+                      <DXSystemType>Packaged/unitary heat pump</DXSystemType>
+                      <CompressorType>Reciprocating</CompressorType>
+                      <CompressorStaging>Single stage</CompressorStaging>
+                    </DX>
+                  </CoolingSourceType>
+                  <AnnualCoolingEfficiencyValue>2.610000</AnnualCoolingEfficiencyValue>
+                  <AnnualCoolingEfficiencyUnits>COP</AnnualCoolingEfficiencyUnits>
+                  <Capacity>10198.900000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <CoolingSourceCondition>Good</CoolingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </CoolingSource>
+                <CoolingSource ID="CoolingSource-2">
+                  <CoolingSourceType>
+                    <DX>
+                      <DXSystemType>Packaged/unitary heat pump</DXSystemType>
+                      <CompressorType>Reciprocating</CompressorType>
+                      <CompressorStaging>Single stage</CompressorStaging>
+                    </DX>
+                  </CoolingSourceType>
+                  <AnnualCoolingEfficiencyValue>2.610000</AnnualCoolingEfficiencyValue>
+                  <AnnualCoolingEfficiencyUnits>COP</AnnualCoolingEfficiencyUnits>
+                  <Capacity>9847.200000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <CoolingSourceCondition>Good</CoolingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </CoolingSource>
+                <CoolingSource ID="CoolingSource-3">
+                  <CoolingSourceType>
+                    <DX>
+                      <DXSystemType>Packaged/unitary heat pump</DXSystemType>
+                      <CompressorType>Reciprocating</CompressorType>
+                      <CompressorStaging>Single stage</CompressorStaging>
+                    </DX>
+                  </CoolingSourceType>
+                  <AnnualCoolingEfficiencyValue>2.610000</AnnualCoolingEfficiencyValue>
+                  <AnnualCoolingEfficiencyUnits>COP</AnnualCoolingEfficiencyUnits>
+                  <Capacity>7737.100000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <CoolingSourceCondition>Good</CoolingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </CoolingSource>
+                <CoolingSource ID="CoolingSource-4">
+                  <CoolingSourceType>
+                    <DX>
+                      <DXSystemType>Packaged/unitary heat pump</DXSystemType>
+                      <CompressorType>Reciprocating</CompressorType>
+                      <CompressorStaging>Single stage</CompressorStaging>
+                    </DX>
+                  </CoolingSourceType>
+                  <AnnualCoolingEfficiencyValue>2.610000</AnnualCoolingEfficiencyValue>
+                  <AnnualCoolingEfficiencyUnits>COP</AnnualCoolingEfficiencyUnits>
+                  <Capacity>9143.800000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <CoolingSourceCondition>Good</CoolingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </CoolingSource>
+                <CoolingSource ID="CoolingSource-5">
+                  <CoolingSourceType>
+                    <DX>
+                      <DXSystemType>Packaged/unitary heat pump</DXSystemType>
+                      <CompressorType>Reciprocating</CompressorType>
+                      <CompressorStaging>Single stage</CompressorStaging>
+                    </DX>
+                  </CoolingSourceType>
+                  <AnnualCoolingEfficiencyValue>2.610000</AnnualCoolingEfficiencyValue>
+                  <AnnualCoolingEfficiencyUnits>COP</AnnualCoolingEfficiencyUnits>
+                  <Capacity>9847.200000</Capacity>
+                  <CapacityUnits>W</CapacityUnits>
+                  <CoolingSourceCondition>Good</CoolingSourceCondition>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                </CoolingSource>
+              </CoolingSources>
+              <Deliveries>
+                <Delivery ID="Delivery-1">
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <AirDeliveryType>Central fan</AirDeliveryType>
+                      <TerminalUnit>CAV terminal box no reheat</TerminalUnit>
+                      <ReheatSource>None</ReheatSource>
+                      <FanBased>
+                        <AirSideEconomizer ID="AirSideEconomizer-1">
+                          <AirSideEconomizerType>None</AirSideEconomizerType>
+                          <EconomizerControl>Fixed</EconomizerControl>
+                        </AirSideEconomizer>
+                      </FanBased>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource-1"/>
+                  <CoolingSourceID IDref="CoolingSource-1"/>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                  <Quantity>1</Quantity>
+                  <DeliveryCondition>Good</DeliveryCondition>
+                </Delivery>
+                <Delivery ID="Delivery-2">
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <AirDeliveryType>Central fan</AirDeliveryType>
+                      <TerminalUnit>CAV terminal box no reheat</TerminalUnit>
+                      <ReheatSource>None</ReheatSource>
+                      <FanBased>
+                        <AirSideEconomizer ID="AirSideEconomizer-2">
+                          <AirSideEconomizerType>None</AirSideEconomizerType>
+                          <EconomizerControl>Fixed</EconomizerControl>
+                        </AirSideEconomizer>
+                      </FanBased>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource-2"/>
+                  <CoolingSourceID IDref="CoolingSource-2"/>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                  <Quantity>1</Quantity>
+                  <DeliveryCondition>Good</DeliveryCondition>
+                </Delivery>
+                <Delivery ID="Delivery-3">
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <AirDeliveryType>Central fan</AirDeliveryType>
+                      <TerminalUnit>CAV terminal box no reheat</TerminalUnit>
+                      <ReheatSource>None</ReheatSource>
+                      <FanBased>
+                        <AirSideEconomizer ID="AirSideEconomizer-3">
+                          <AirSideEconomizerType>None</AirSideEconomizerType>
+                          <EconomizerControl>Fixed</EconomizerControl>
+                        </AirSideEconomizer>
+                      </FanBased>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource-3"/>
+                  <CoolingSourceID IDref="CoolingSource-3"/>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                  <Quantity>1</Quantity>
+                  <DeliveryCondition>Good</DeliveryCondition>
+                </Delivery>
+                <Delivery ID="Delivery-4">
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <AirDeliveryType>Central fan</AirDeliveryType>
+                      <TerminalUnit>CAV terminal box no reheat</TerminalUnit>
+                      <ReheatSource>None</ReheatSource>
+                      <FanBased>
+                        <AirSideEconomizer ID="AirSideEconomizer-4">
+                          <AirSideEconomizerType>None</AirSideEconomizerType>
+                          <EconomizerControl>Fixed</EconomizerControl>
+                        </AirSideEconomizer>
+                      </FanBased>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource-4"/>
+                  <CoolingSourceID IDref="CoolingSource-4"/>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                  <Quantity>1</Quantity>
+                  <DeliveryCondition>Good</DeliveryCondition>
+                </Delivery>
+                <Delivery ID="Delivery-5">
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <AirDeliveryType>Central fan</AirDeliveryType>
+                      <TerminalUnit>CAV terminal box no reheat</TerminalUnit>
+                      <ReheatSource>None</ReheatSource>
+                      <FanBased>
+                        <AirSideEconomizer ID="AirSideEconomizer-5">
+                          <AirSideEconomizerType>None</AirSideEconomizerType>
+                          <EconomizerControl>Fixed</EconomizerControl>
+                        </AirSideEconomizer>
+                      </FanBased>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource-5"/>
+                  <CoolingSourceID IDref="CoolingSource-5"/>
+                  <Controls>
+                    <Control>
+                      <OtherControlTechnology>
+                        <ControlSystemType>
+                          <Digital/>
+                        </ControlSystemType>
+                      </OtherControlTechnology>
+                    </Control>
+                  </Controls>
+                  <YearInstalled>2000</YearInstalled>
+                  <Quantity>1</Quantity>
+                  <DeliveryCondition>Good</DeliveryCondition>
+                </Delivery>
+              </Deliveries>
+            </HeatingAndCoolingSystems>
+            <DuctSystems>
+              <DuctSystem ID="DuctSystem-1">
+                <DuctConfiguration>Single</DuctConfiguration>
+                <DuctInsulationCondition>Good</DuctInsulationCondition>
+                <HeatingDeliveryID IDref="Delivery-1"/>
+                <CoolingDeliveryID IDref="Delivery-1"/>
+              </DuctSystem>
+              <DuctSystem ID="DuctSystem-2">
+                <DuctConfiguration>Single</DuctConfiguration>
+                <DuctInsulationCondition>Good</DuctInsulationCondition>
+                <HeatingDeliveryID IDref="Delivery-2"/>
+                <CoolingDeliveryID IDref="Delivery-2"/>
+              </DuctSystem>
+              <DuctSystem ID="DuctSystem-3">
+                <DuctConfiguration>Single</DuctConfiguration>
+                <DuctInsulationCondition>Good</DuctInsulationCondition>
+                <HeatingDeliveryID IDref="Delivery-3"/>
+                <CoolingDeliveryID IDref="Delivery-3"/>
+              </DuctSystem>
+              <DuctSystem ID="DuctSystem-4">
+                <DuctConfiguration>Single</DuctConfiguration>
+                <DuctInsulationCondition>Good</DuctInsulationCondition>
+                <HeatingDeliveryID IDref="Delivery-4"/>
+                <CoolingDeliveryID IDref="Delivery-4"/>
+              </DuctSystem>
+              <DuctSystem ID="DuctSystem-5">
+                <DuctConfiguration>Single</DuctConfiguration>
+                <DuctInsulationCondition>Good</DuctInsulationCondition>
+                <HeatingDeliveryID IDref="Delivery-5"/>
+                <CoolingDeliveryID IDref="Delivery-5"/>
+              </DuctSystem>
+            </DuctSystems>
+            <HVACControlSystemTypes>
+              <HVACControlSystemType>Digital</HVACControlSystemType>
+            </HVACControlSystemTypes>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-office">
+                  <LinkedScheduleIDs>
+                    <LinkedScheduleID IDref="Schedule-HVAC"/>
+                  </LinkedScheduleIDs>
+                </LinkedSectionID>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+        </HVACSystems>
+        <LightingSystems>
+          <LightingSystem ID="LightingSystem-1">
+            <LampType>
+              <LinearFluorescent>
+                <LampLabel>T8</LampLabel>
+              </LinearFluorescent>
+            </LampType>
+            <BallastType>Standard Electronic</BallastType>
+            <DimmingCapability>
+              <MinimumDimmingLightFraction>0.200000</MinimumDimmingLightFraction>
+            </DimmingCapability>
+            <PercentPremisesServed>100.000000</PercentPremisesServed>
+            <InstalledPower>5.500000</InstalledPower>
+            <LampPower>32.000000</LampPower>
+            <NumberOfLampsPerBallast>4</NumberOfLampsPerBallast>
+            <NumberOfBallastsPerLuminaire>1.000000</NumberOfBallastsPerLuminaire>
+            <NumberOfLuminaires>43</NumberOfLuminaires>
+            <OutsideLighting>false</OutsideLighting>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlSystemType>
+                    <Digital/>
+                  </ControlSystemType>
+                  <ControlStrategy>Programmable</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
+            <LightingAutomationSystem>false</LightingAutomationSystem>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-office">
+                  <LinkedScheduleIDs>
+                    <LinkedScheduleID IDref="Schedule-Lighting"/>
+                  </LinkedScheduleIDs>
+                </LinkedSectionID>
+              </Section>
+            </LinkedPremises>
+          </LightingSystem>
+          <LightingSystem ID="LightingSystem-2">
+            <LampType>
+              <LinearFluorescent>
+                <LampLabel>T12</LampLabel>
+              </LinearFluorescent>
+            </LampType>
+            <BallastType>Standard Electronic</BallastType>
+            <PercentPremisesServed>100.000000</PercentPremisesServed>
+            <InstalledPower>1.582575</InstalledPower>
+            <LampPower>316.516000</LampPower>
+            <NumberOfLampsPerBallast>1</NumberOfLampsPerBallast>
+            <NumberOfBallastsPerLuminaire>1.000000</NumberOfBallastsPerLuminaire>
+            <NumberOfLuminaires>5</NumberOfLuminaires>
+            <OutsideLighting>true</OutsideLighting>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlSystemType>
+                    <Digital/>
+                  </ControlSystemType>
+                  <ControlStrategy>Programmable</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
+            <LightingAutomationSystem>false</LightingAutomationSystem>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-Whole-building">
+                  <LinkedScheduleIDs>
+                    <LinkedScheduleID IDref="Schedule-Lighting"/>
+                  </LinkedScheduleIDs>
+                </LinkedSectionID>
+              </Section>
+            </LinkedPremises>
+          </LightingSystem>
+          <LightingSystem ID="LightingSystem-new">
+            <LampType>
+              <SolidStateLighting>
+                <LampLabel>LED</LampLabel>
+              </SolidStateLighting>
+            </LampType>
+            <BallastType>Standard Electronic</BallastType>
+            <DimmingCapability>
+              <MinimumDimmingLightFraction>0.100000</MinimumDimmingLightFraction>
+            </DimmingCapability>
+            <PercentPremisesServed>100.000000</PercentPremisesServed>
+            <InstalledPower>2.752000</InstalledPower>
+            <LampPower>16.000000</LampPower>
+            <NumberOfLampsPerBallast>4</NumberOfLampsPerBallast>
+            <NumberOfBallastsPerLuminaire>1.000000</NumberOfBallastsPerLuminaire>
+            <NumberOfLuminaires>43</NumberOfLuminaires>
+            <OutsideLighting>false</OutsideLighting>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSystemType>
+                    <Digital/>
+                  </ControlSystemType>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlStrategy>Continuous</ControlStrategy>
+                </Daylighting>
+              </Control>
+            </Controls>
+            <LightingAutomationSystem>false</LightingAutomationSystem>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-office">
+                  <LinkedScheduleIDs>
+                    <LinkedScheduleID IDref="Schedule-Lighting"/>
+                  </LinkedScheduleIDs>
+                </LinkedSectionID>
+              </Section>
+            </LinkedPremises>
+          </LightingSystem>
+        </LightingSystems>
+        <DomesticHotWaterSystems>
+          <DomesticHotWaterSystem ID="SHW-1">
+            <DomesticHotWaterType>
+              <StorageTank>
+                <TankHeatingType>
+                  <Unknown/>
+                </TankHeatingType>
+                <TankVolume>40.000000</TankVolume>
+                <StorageTankInsulationRValue>123.000000</StorageTankInsulationRValue>
+              </StorageTank>
+            </DomesticHotWaterType>
+            <DomesticHotWaterSystemNotes>Notes</DomesticHotWaterSystemNotes>
+            <Recirculation>
+              <RecirculationLoopCount>1</RecirculationLoopCount>
+              <RecirculationFlowRate>3.600000</RecirculationFlowRate>
+              <RecirculationControlType>Continuous</RecirculationControlType>
+              <PipeInsulationThickness>123.000000</PipeInsulationThickness>
+              <RecirculationEnergyLossRate>1.870180</RecirculationEnergyLossRate>
+            </Recirculation>
+            <HotWaterDistributionType>Looped</HotWaterDistributionType>
+            <WaterHeaterEfficiencyType>Thermal Efficiency</WaterHeaterEfficiencyType>
+            <WaterHeaterEfficiency>1.000000</WaterHeaterEfficiency>
+            <DailyHotWaterDraw>40.000000</DailyHotWaterDraw>
+            <HotWaterSetpointTemperature>140.000000</HotWaterSetpointTemperature>
+            <ParasiticFuelConsumptionRate>1950.520000</ParasiticFuelConsumptionRate>
+            <Capacity>11722.840000</Capacity>
+            <CapacityUnits>W</CapacityUnits>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlSystemType>
+                    <Other/>
+                  </ControlSystemType>
+                </Manual>
+              </Control>
+            </Controls>
+            <YearInstalled>2000</YearInstalled>
+            <PrimaryFuel>Electricity</PrimaryFuel>
+            <DomesticHotWaterSystemCondition>Good</DomesticHotWaterSystemCondition>
+            <LinkedPremises>
+              <Building>
+                <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+              </Building>
+              <Section>
+                <LinkedSectionID IDref="Section-office"/>
+              </Section>
+            </LinkedPremises>
+            <Quantity>1</Quantity>
+          </DomesticHotWaterSystem>
+        </DomesticHotWaterSystems>
+        <FanSystems>
+          <FanSystem ID="FanSystem-1">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>880.000000</FanSize>
+            <FanInstalledFlowRate>880.000000</FanInstalledFlowRate>
+            <FanControlType>Constant Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-1"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-1-new">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>872.000000</FanSize>
+            <InstalledFlowRate>872.000000</InstalledFlowRate>
+            <FanControlType>Variable Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-1"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-2">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>836.000000</FanSize>
+            <FanInstalledFlowRate>836.000000</FanInstalledFlowRate>
+            <FanControlType>Constant Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-2"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-2-new">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>830.000000</FanSize>
+            <InstalledFlowRate>830.000000</InstalledFlowRate>
+            <FanControlType>Variable Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-2"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-3">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>671.000000</FanSize>
+            <FanInstalledFlowRate>671.000000</FanInstalledFlowRate>
+            <FanControlType>Constant Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-3"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-3-new">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>664.000000</FanSize>
+            <InstalledFlowRate>664.000000</InstalledFlowRate>
+            <FanControlType>Variable Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-3"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-4">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>774.000000</FanSize>
+            <FanInstalledFlowRate>774.000000</FanInstalledFlowRate>
+            <FanControlType>Constant Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-4"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-4-new">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>766.000000</FanSize>
+            <InstalledFlowRate>766.000000</InstalledFlowRate>
+            <FanControlType>Variable Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-4"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-5">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>841.000000</FanSize>
+            <FanInstalledFlowRate>841.000000</FanInstalledFlowRate>
+            <FanControlType>Constant Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-5"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+          <FanSystem ID="FanSystem-5-new">
+            <FanEfficiency>0.536000</FanEfficiency>
+            <FanSize>833.000000</FanSize>
+            <InstalledFlowRate>833.000000</InstalledFlowRate>
+            <FanControlType>Variable Volume</FanControlType>
+            <LinkedSystemIDs>
+              <LinkedSystemID IDref="Delivery-5"/>
+            </LinkedSystemIDs>
+          </FanSystem>
+        </FanSystems>
+        <WallSystems>
+          <WallSystem ID="Wall-1">
+            <ExteriorWallConstruction>Wood frame</ExteriorWallConstruction>
+            <WallUFactor>0.547000</WallUFactor>
+          </WallSystem>
+        </WallSystems>
+        <RoofSystems>
+          <RoofSystem ID="Roof-1">
+            <RoofConstruction>Wood frame</RoofConstruction>
+            <RoofUFactor>4.706000</RoofUFactor>
+          </RoofSystem>
+        </RoofSystems>
+        <FenestrationSystems>
+          <FenestrationSystem ID="Window-1-Original">
+            <FenestrationType>
+              <Window/>
+            </FenestrationType>
+            <FenestrationFrameMaterial>Vinyl</FenestrationFrameMaterial>
+            <GlassType>Clear uncoated</GlassType>
+            <FenestrationGlassLayers>Single pane</FenestrationGlassLayers>
+            <FenestrationUFactor>3.241000</FenestrationUFactor>
+            <SolarHeatGainCoefficient>0.391000</SolarHeatGainCoefficient>
+            <VisibleTransmittance>0.391000</VisibleTransmittance>
+          </FenestrationSystem>
+          <FenestrationSystem ID="Window-1">
+            <FenestrationType>
+              <Window/>
+            </FenestrationType>
+            <FenestrationFrameMaterial>Vinyl</FenestrationFrameMaterial>
+            <GlassType>Low e</GlassType>
+            <FenestrationGlassLayers>Triple pane</FenestrationGlassLayers>
+            <FenestrationUFactor>0.300000</FenestrationUFactor>
+            <SolarHeatGainCoefficient>0.391000</SolarHeatGainCoefficient>
+            <VisibleTransmittance>0.391000</VisibleTransmittance>
+          </FenestrationSystem>
+          <FenestrationSystem ID="Door-1">
+            <FenestrationType>
+              <Door>
+                <ExteriorDoorType>Insulated metal</ExteriorDoorType>
+                <DoorGlazedAreaFraction>0.500000</DoorGlazedAreaFraction>
+              </Door>
+            </FenestrationType>
+            <FenestrationFrameMaterial>Steel</FenestrationFrameMaterial>
+            <FenestrationUFactor>2.839000</FenestrationUFactor>
+          </FenestrationSystem>
+        </FenestrationSystems>
+        <FoundationSystems>
+          <FoundationSystem ID="Foundation-1">
+            <GroundCouplings>
+              <GroundCoupling>
+                <SlabOnGrade>
+                  <SlabUFactor>0.345000</SlabUFactor>
+                </SlabOnGrade>
+              </GroundCoupling>
+            </GroundCouplings>
+            <FloorConstructionType>Concrete poured</FloorConstructionType>
+          </FoundationSystem>
+        </FoundationSystems>
+        <PlugLoads>
+          <PlugLoad ID="PlugLoad-1">
+            <PlugLoadType>Miscellaneous Electric Load</PlugLoadType>
+            <WeightedAverageLoad>0.630000</WeightedAverageLoad>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-office">
+                  <LinkedScheduleIDs>
+                    <LinkedScheduleID IDref="Schedule-PlugLoad"/>
+                  </LinkedScheduleIDs>
+                </LinkedSectionID>
+              </Section>
+            </LinkedPremises>
+          </PlugLoad>
+        </PlugLoads>
+        <AirInfiltrationSystems>
+          <AirInfiltrationSystem ID="Infiltration-1">
+            <AirInfiltrationNotes>Notes on test</AirInfiltrationNotes>
+            <Tightness>Tight</Tightness>
+            <AirInfiltrationValue>0.151000</AirInfiltrationValue>
+            <AirInfiltrationValueUnits>ACHnatural</AirInfiltrationValueUnits>
+            <AirInfiltrationTest>Blower door</AirInfiltrationTest>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-Whole-building"/>
+              </Section>
+            </LinkedPremises>
+          </AirInfiltrationSystem>
+        </AirInfiltrationSystems>
+        <WaterInfiltrationSystems>
+          <WaterInfiltrationSystem>
+            <WaterInfiltrationNotes>Notes on test</WaterInfiltrationNotes>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-Whole-building"/>
+              </Section>
+            </LinkedPremises>
+          </WaterInfiltrationSystem>
+        </WaterInfiltrationSystems>
+      </Systems>
+      <Schedules>
+        <Schedule ID="Schedule-Occupancy">
+          <ScheduleDetails>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>06:00:00</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>06:00:00</DayStartTime>
+              <DayEndTime>07:00:00</DayEndTime>
+              <PartialOperationPercentage>11.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>07:00:00</DayStartTime>
+              <DayEndTime>08:00:00</DayEndTime>
+              <PartialOperationPercentage>21.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>08:00:00</DayStartTime>
+              <DayEndTime>12:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>12:00:00</DayStartTime>
+              <DayEndTime>13:00:00</DayEndTime>
+              <PartialOperationPercentage>53.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>13:00:00</DayStartTime>
+              <DayEndTime>17:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>17:00:00</DayStartTime>
+              <DayEndTime>18:00:00</DayEndTime>
+              <PartialOperationPercentage>32.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>18:00:00</DayStartTime>
+              <DayEndTime>22:00:00</DayEndTime>
+              <PartialOperationPercentage>11.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>22:00:00</DayStartTime>
+              <DayEndTime>23:00:00</DayEndTime>
+              <PartialOperationPercentage>5.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>23:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekend</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Holiday</DayType>
+              <ScheduleCategory>Occupied</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+          </ScheduleDetails>
+          <LinkedPremises>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+            <Section>
+              <LinkedSectionID IDref="Section-office"/>
+            </Section>
+          </LinkedPremises>
+        </Schedule>
+        <Schedule ID="Schedule-Lighting">
+          <ScheduleDetails>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>05:00:00</DayEndTime>
+              <PartialOperationPercentage>18.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>05:00:00</DayStartTime>
+              <DayEndTime>07:00:00</DayEndTime>
+              <PartialOperationPercentage>23.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>07:00:00</DayStartTime>
+              <DayEndTime>08:00:00</DayEndTime>
+              <PartialOperationPercentage>42.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>08:00:00</DayStartTime>
+              <DayEndTime>12:00:00</DayEndTime>
+              <PartialOperationPercentage>90.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>12:00:00</DayStartTime>
+              <DayEndTime>13:00:00</DayEndTime>
+              <PartialOperationPercentage>80.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>13:00:00</DayStartTime>
+              <DayEndTime>17:00:00</DayEndTime>
+              <PartialOperationPercentage>90.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>17:00:00</DayStartTime>
+              <DayEndTime>18:00:00</DayEndTime>
+              <PartialOperationPercentage>61.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>18:00:00</DayStartTime>
+              <DayEndTime>20:00:00</DayEndTime>
+              <PartialOperationPercentage>42.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>20:00:00</DayStartTime>
+              <DayEndTime>22:00:00</DayEndTime>
+              <PartialOperationPercentage>32.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>22:00:00</DayStartTime>
+              <DayEndTime>23:00:00</DayEndTime>
+              <PartialOperationPercentage>23.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>23:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>18.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekend</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>18.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Holiday</DayType>
+              <ScheduleCategory>Lighting</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>18.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+          </ScheduleDetails>
+          <LinkedPremises>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremises>
+        </Schedule>
+        <Schedule ID="Schedule-PlugLoad">
+          <ScheduleDetails>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>08:00:00</DayEndTime>
+              <PartialOperationPercentage>50.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>08:00:00</DayStartTime>
+              <DayEndTime>12:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>12:00:00</DayStartTime>
+              <DayEndTime>13:00:00</DayEndTime>
+              <PartialOperationPercentage>94.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>13:00:00</DayStartTime>
+              <DayEndTime>17:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>17:00:00</DayStartTime>
+              <DayEndTime>18:00:00</DayEndTime>
+              <PartialOperationPercentage>50.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>18:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>20.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekend</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>20.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Holiday</DayType>
+              <ScheduleCategory>Miscellaneous equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>20.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+          </ScheduleDetails>
+          <LinkedPremises>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremises>
+        </Schedule>
+        <Schedule ID="Schedule-HVAC">
+          <ScheduleDetails>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>06:00:00</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>06:00:00</DayStartTime>
+              <DayEndTime>19:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>19:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekend</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Holiday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+          </ScheduleDetails>
+          <LinkedPremises>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremises>
+        </Schedule>
+        <Schedule ID="Schedule-HVAC-new">
+          <ScheduleDetails>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>06:00:00</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>06:00:00</DayStartTime>
+              <DayEndTime>07:00:00</DayEndTime>
+              <PartialOperationPercentage>60.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>07:00:00</DayStartTime>
+              <DayEndTime>12:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>12:00:00</DayStartTime>
+              <DayEndTime>13:00:00</DayEndTime>
+              <PartialOperationPercentage>80.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>13:00:00</DayStartTime>
+              <DayEndTime>18:00:00</DayEndTime>
+              <PartialOperationPercentage>100.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>18:00:00</DayStartTime>
+              <DayEndTime>20:00:00</DayEndTime>
+              <PartialOperationPercentage>60.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>20:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Weekend</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+            <ScheduleDetail>
+              <DayType>Holiday</DayType>
+              <ScheduleCategory>HVAC equipment</ScheduleCategory>
+              <DayStartTime>00:00:00</DayStartTime>
+              <DayEndTime>23:59:59</DayEndTime>
+              <PartialOperationPercentage>0.000000</PartialOperationPercentage>
+            </ScheduleDetail>
+          </ScheduleDetails>
+          <LinkedPremises>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremises>
+        </Schedule>
+      </Schedules>
+      <Measures>
+        <Measure ID="Measure-LEDs">
+          <TypeOfMeasure>
+            <Replacements>
+              <Replacement>
+                <ExistingSystemReplaced IDref="LightingSystem-1"/>
+                <AlternativeSystemReplacement IDref="LightingSystem-new"/>
+              </Replacement>
+            </Replacements>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Lighting</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <LightingImprovements>
+                <MeasureName>Retrofit with light emitting diode technologies</MeasureName>
+              </LightingImprovements>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <MeasureScaleOfApplication>Individual system</MeasureScaleOfApplication>
+          <LongDescription>This measure is designed to replace all fluorescent bulbs with LEDs</LongDescription>
+          <UsefulLife>1</UsefulLife>
+          <MeasureInstallationCost>50.000000</MeasureInstallationCost>
+          <MeasureMaterialCost>774.000000</MeasureMaterialCost>
+          <Recommended>true</Recommended>
+          <StartDate>2021-01-01</StartDate>
+          <EndDate>2021-12-30</EndDate>
+        </Measure>
+        <Measure ID="Measure-VSDs">
+          <TypeOfMeasure>
+            <ModificationRetrocommissions>
+              <ModificationRetrocommissioning>
+                <ExistingSystemAffected IDref="FanSystem-5"/>
+                <ModifiedSystem IDref="FanSystem-5-new"/>
+              </ModificationRetrocommissioning>
+            </ModificationRetrocommissions>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Fan</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <OtherElectricMotorsAndDrives>
+                <MeasureName>Add VSD motor controller</MeasureName>
+              </OtherElectricMotorsAndDrives>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <MeasureScaleOfApplication>Individual system</MeasureScaleOfApplication>
+          <LongDescription>This measure is designed to retrofit all RTU fans with a VSD</LongDescription>
+          <UsefulLife>1</UsefulLife>
+          <MeasureInstallationCost>750.000000</MeasureInstallationCost>
+          <MeasureMaterialCost>1250.000000</MeasureMaterialCost>
+          <Recommended>true</Recommended>
+          <StartDate>2021-01-01</StartDate>
+          <EndDate>2021-12-30</EndDate>
+        </Measure>
+      </Measures>
+      <Reports>
+        <Report ID="Report-L2-Audit">
+          <Scenarios>
+            <Scenario ID="Scenario-measured">
+              <ScenarioType>
+                <CurrentBuilding>
+                  <CalculationMethod>
+                    <Measured/>
+                  </CalculationMethod>
+                </CurrentBuilding>
+              </ScenarioType>
+              <ResourceUses>
+                <ResourceUse ID="ResourceUse-Electricity">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUseNotes>This is required to document irregularities in monthly energy patterns (Std 211 6.1.2.1.j). No irregularities found.</ResourceUseNotes>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>67334.150000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>229.753657</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Total-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <PeakResourceUnits>kW</PeakResourceUnits>
+                  <AnnualPeakNativeUnits>26.040000</AnnualPeakNativeUnits>
+                  <AnnualPeakConsistentUnits>26.040000</AnnualPeakConsistentUnits>
+                  <AnnualFuelCost>4613.820000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Electric"/>
+                  </UtilityIDs>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Natural-gas">
+                  <EnergyResource>Natural gas</EnergyResource>
+                  <ResourceUseNotes>No irregularities in monthly energy consumption found.</ResourceUseNotes>
+                  <ResourceUnits>MMBtu</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>8.720000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>8.720000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Total-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <AnnualFuelCost>540.830000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Natural-Gas"/>
+                  </UtilityIDs>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Electricity-Lighting-Submeter">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>Interior lighting</EndUse>
+                  <PercentEndUse>28.705000</PercentEndUse>
+                  <AnnualFuelUseNativeUnits>20062.690000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>68.453898</AnnualFuelUseConsistentUnits>
+                  <ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Electricity-Heating-Submeter">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>Heating</EndUse>
+                  <PercentEndUse>6.722000</PercentEndUse>
+                  <AnnualFuelUseNativeUnits>4698.230000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>16.030361</AnnualFuelUseConsistentUnits>
+                  <ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Electricity-Cooling-Submeter">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>Cooling</EndUse>
+                  <PercentEndUse>8.769000</PercentEndUse>
+                  <AnnualFuelUseNativeUnits>6128.870000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>20.911704</AnnualFuelUseConsistentUnits>
+                  <ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Electricity-SHW-Submeter">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>Domestic hot water</EndUse>
+                  <PercentEndUse>10.281000</PercentEndUse>
+                  <AnnualFuelUseNativeUnits>7185.370000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>24.516482</AnnualFuelUseConsistentUnits>
+                  <ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Electricity-Plugload-Submeter">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>Plug load</EndUse>
+                  <PercentEndUse>21.379000</PercentEndUse>
+                  <AnnualFuelUseNativeUnits>14942.150000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>50.982616</AnnualFuelUseConsistentUnits>
+                  <ParentResourceUseID IDref="ResourceUse-Electricity"/>
+                </ResourceUse>
+              </ResourceUses>
+              <TimeSeriesData>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5933.100000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5446.100000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5736.490000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4980.500000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5187.210000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5842.950000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5801.730000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6220.160000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5682.870000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5571.930000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5525.150000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Total-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5405.940000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>1.720000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>1.250000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.410000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.430000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.200000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.400000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Total-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-1">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>23.580000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-2">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>25.380000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-3">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>26.040000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-4">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>24.450000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-5">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>17.030000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-6">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>22.710000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-7">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>22.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-8">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.810000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-9">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.630000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-10">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.870000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-11">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.630000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Peak-12">
+                  <ReadingType>Peak</ReadingType>
+                  <PeakType>On-peak</PeakType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.780000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-1">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.340000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-2">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.320000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-3">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-4">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.280000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-5">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.410000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-6">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.360000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-7">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.350000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-8">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.380000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-9">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.380000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-10">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.340000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-11">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.350000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Loadfactor-12">
+                  <ReadingType>Load factor</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.330000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>332.160000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>306.290000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>321.720000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>281.540000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>292.530000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>534.100000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>530.450000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>567.490000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>519.930000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>312.970000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>310.490000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>304.150000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>46.690000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>28</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>45.930000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>44.550000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>44.580000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>43.900000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>43.880000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>43.880000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>43.880000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>43.880000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>44.210000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>30</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>44.530000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalDuration>31</IntervalDuration>
+                  <IntervalDurationUnits>Day</IntervalDurationUnits>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>50.920000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+              </TimeSeriesData>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-1">
+                  <SiteEnergyUse>238473.656550</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>43.358800</SiteEnergyUseIntensity>
+                  <SourceEnergyUse>737088.900000</SourceEnergyUse>
+                  <SourceEnergyUseIntensity>134.000000</SourceEnergyUseIntensity>
+                  <BuildingEnergyUse>238473.656550</BuildingEnergyUse>
+                  <BuildingEnergyUseIntensity>43.358800</BuildingEnergyUseIntensity>
+                  <ImportedEnergyConsistentUnits>238.473657</ImportedEnergyConsistentUnits>
+                  <OnsiteEnergyProductionConsistentUnits>0.000000</OnsiteEnergyProductionConsistentUnits>
+                  <ExportedEnergyConsistentUnits>0.000000</ExportedEnergyConsistentUnits>
+                  <NetIncreaseInStoredEnergyConsistentUnits>0.000000</NetIncreaseInStoredEnergyConsistentUnits>
+                  <EnergyCost>4952.480000</EnergyCost>
+                  <EnergyCostIndex>0.900000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-Benchmark">
+              <ScenarioType>
+                <Benchmark>
+                  <BenchmarkType>
+                    <PortfolioManager>
+                      <PMBenchmarkDate>2022-06-01</PMBenchmarkDate>
+                    </PortfolioManager>
+                  </BenchmarkType>
+                  <BenchmarkTool>Portfolio Manager</BenchmarkTool>
+                  <BenchmarkYear>2019</BenchmarkYear>
+                  <BenchmarkValue>80.000000</BenchmarkValue>
+                </Benchmark>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Benchmark">
+                  <SiteEnergyUse>238473.656550</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>43.358800</SiteEnergyUseIntensity>
+                  <EnergyCost>4952.480000</EnergyCost>
+                </AllResourceTotal>
+              </AllResourceTotals>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-Target">
+              <ScenarioType>
+                <Target>
+                  <ReferenceCase IDref="Scenario-Benchmark"/>
+                  <AnnualSavingsSiteEnergy>39070.530000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>995</AnnualSavingsCost>
+                  <ENERGYSTARScore>89.000000</ENERGYSTARScore>
+                </Target>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Target">
+                  <SiteEnergyUse>190348.600000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>34.600000</SiteEnergyUseIntensity>
+                  <EnergyCost>4846.040000</EnergyCost>
+                  <EnergyCostIndex>0.881000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-Modeled">
+              <ScenarioType>
+                <CurrentBuilding>
+                  <CalculationMethod>
+                    <Modeled>
+                      <WeatherDataType>TMY3</WeatherDataType>
+                      <SimulationCompletionStatus>Finished</SimulationCompletionStatus>
+                    </Modeled>
+                  </CalculationMethod>
+                </CurrentBuilding>
+              </ScenarioType>
+              <ResourceUses>
+                <ResourceUse ID="ResourceUse-Electricity-modeled">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>67334.150000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>229.753657</AnnualFuelUseConsistentUnits>
+                  <PeakResourceUnits>kW</PeakResourceUnits>
+                  <AnnualPeakNativeUnits>26.040000</AnnualPeakNativeUnits>
+                  <AnnualPeakConsistentUnits>26.040000</AnnualPeakConsistentUnits>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Natural-gas-modeled">
+                  <EnergyResource>Natural gas</EnergyResource>
+                  <ResourceUnits>MMBtu</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>8.720000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>8.720000</AnnualFuelUseConsistentUnits>
+                </ResourceUse>
+              </ResourceUses>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs">
+              <ScenarioName>POM-LEDs</ScenarioName>
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs">
+                  <ReferenceCase IDref="Scenario-measured"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <AnnualSavingsSiteEnergy>35.713000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>772</AnnualSavingsCost>
+                  <AnnualSavingsByFuels>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Electricity</EnergyResource>
+                      <ResourceUnits>kWh</ResourceUnits>
+                      <AnnualSavingsNativeUnits>11524.540000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Natural gas</EnergyResource>
+                      <ResourceUnits>MMBtu</ResourceUnits>
+                      <AnnualSavingsNativeUnits>0.000000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                  </AnnualSavingsByFuels>
+                  <AnnualPeakElectricityReduction>3.220000</AnnualPeakElectricityReduction>
+                  <AnnualDemandSavingsCost>0</AnnualDemandSavingsCost>
+                  <AnnualWaterSavings>0.000000</AnnualWaterSavings>
+                  <AnnualWaterCostSavings>0.000000</AnnualWaterCostSavings>
+                  <ImplementationPeriod>1</ImplementationPeriod>
+                  <PackageFirstCost>824.000000</PackageFirstCost>
+                  <MVCost>0.000000</MVCost>
+                  <OMCostAnnualSavings>0.000000</OMCostAnnualSavings>
+                  <EquipmentDisposalAndSalvageCosts>0.000000</EquipmentDisposalAndSalvageCosts>
+                  <ImplementationPeriodCostSavings>0.000000</ImplementationPeriodCostSavings>
+                  <ProjectMarkup>0.000000</ProjectMarkup>
+                  <FundingFromIncentives>0.000000</FundingFromIncentives>
+                  <FundingFromTaxCredits>0.000000</FundingFromTaxCredits>
+                  <OtherFinancialIncentives>0</OtherFinancialIncentives>
+                  <RecurringIncentives>0</RecurringIncentives>
+                  <SimplePayback>1.070000</SimplePayback>
+                  <InternalRateOfReturn>0.000000</InternalRateOfReturn>
+                </PackageOfMeasures>
+              </ScenarioType>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-POM-VSDs">
+              <ScenarioName>POM-VSDs</ScenarioName>
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-VSDs">
+                  <ReferenceCase IDref="Scenario-measured"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <AnnualSavingsSiteEnergy>5.175000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>9</AnnualSavingsCost>
+                  <AnnualSavingsByFuels>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Electricity</EnergyResource>
+                      <ResourceUnits>kWh</ResourceUnits>
+                      <AnnualSavingsNativeUnits>207.240000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Natural gas</EnergyResource>
+                      <ResourceUnits>MMBtu</ResourceUnits>
+                      <AnnualSavingsNativeUnits>4.460000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                  </AnnualSavingsByFuels>
+                  <AnnualPeakElectricityReduction>0.420000</AnnualPeakElectricityReduction>
+                  <AnnualDemandSavingsCost>0</AnnualDemandSavingsCost>
+                  <AnnualWaterSavings>0.000000</AnnualWaterSavings>
+                  <AnnualWaterCostSavings>0.000000</AnnualWaterCostSavings>
+                  <ImplementationPeriod>1</ImplementationPeriod>
+                  <PackageFirstCost>2000.000000</PackageFirstCost>
+                  <MVCost>0.000000</MVCost>
+                  <OMCostAnnualSavings>0.000000</OMCostAnnualSavings>
+                  <EquipmentDisposalAndSalvageCosts>0.000000</EquipmentDisposalAndSalvageCosts>
+                  <ImplementationPeriodCostSavings>0.000000</ImplementationPeriodCostSavings>
+                  <ProjectMarkup>0.000000</ProjectMarkup>
+                  <FundingFromIncentives>0.000000</FundingFromIncentives>
+                  <FundingFromTaxCredits>0.000000</FundingFromTaxCredits>
+                  <OtherFinancialIncentives>0</OtherFinancialIncentives>
+                  <RecurringIncentives>0</RecurringIncentives>
+                  <SimplePayback>230.150000</SimplePayback>
+                  <InternalRateOfReturn>0.000000</InternalRateOfReturn>
+                </PackageOfMeasures>
+              </ScenarioType>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs-VSDs">
+              <ScenarioName>POM-LEDs-VSDs</ScenarioName>
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs-VSDs">
+                  <ReferenceCase IDref="Scenario-measured"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <AnnualSavingsSiteEnergy>41.827000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>781</AnnualSavingsCost>
+                  <AnnualSavingsByFuels>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Electricity</EnergyResource>
+                      <ResourceUnits>kWh</ResourceUnits>
+                      <AnnualSavingsNativeUnits>11701.620000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Natural gas</EnergyResource>
+                      <ResourceUnits>MMBtu</ResourceUnits>
+                      <AnnualSavingsNativeUnits>1.890000</AnnualSavingsNativeUnits>
+                    </AnnualSavingsByFuel>
+                  </AnnualSavingsByFuels>
+                  <AnnualPeakElectricityReduction>4.700000</AnnualPeakElectricityReduction>
+                  <AnnualDemandSavingsCost>0</AnnualDemandSavingsCost>
+                  <AnnualWaterSavings>0.000000</AnnualWaterSavings>
+                  <AnnualWaterCostSavings>0.000000</AnnualWaterCostSavings>
+                  <ImplementationPeriod>1</ImplementationPeriod>
+                  <PackageFirstCost>2824.000000</PackageFirstCost>
+                  <MVCost>0.000000</MVCost>
+                  <OMCostAnnualSavings>0.000000</OMCostAnnualSavings>
+                  <EquipmentDisposalAndSalvageCosts>0.000000</EquipmentDisposalAndSalvageCosts>
+                  <ImplementationPeriodCostSavings>0.000000</ImplementationPeriodCostSavings>
+                  <ProjectMarkup>0.000000</ProjectMarkup>
+                  <FundingFromIncentives>0.000000</FundingFromIncentives>
+                  <FundingFromTaxCredits>0.000000</FundingFromTaxCredits>
+                  <OtherFinancialIncentives>0</OtherFinancialIncentives>
+                  <RecurringIncentives>0</RecurringIncentives>
+                  <SimplePayback>3.620000</SimplePayback>
+                  <InternalRateOfReturn>0.000000</InternalRateOfReturn>
+                </PackageOfMeasures>
+              </ScenarioType>
+              <LinkedPremises>
+                <Building>
+                  <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+                </Building>
+              </LinkedPremises>
+            </Scenario>
+          </Scenarios>
+          <ASHRAEAuditLevel>Level 2: Energy Survey and Analysis</ASHRAEAuditLevel>
+          <Utilities>
+            <Utility ID="Utility-Electric">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Electricity">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--06-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--09-30</ApplicableEndDateForEnergyRate>
+                          <ApplicableStartDateForDemandRate>--06-01</ApplicableStartDateForDemandRate>
+                          <ApplicableEndDateForDemandRate>--09-30</ApplicableEndDateForDemandRate>
+                          <EnergyCostRate>0.088520</EnergyCostRate>
+                          <ElectricDemandRate>0.000000</ElectricDemandRate>
+                        </RatePeriod>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--05-31</ApplicableEndDateForEnergyRate>
+                          <ApplicableStartDateForDemandRate>--01-01</ApplicableStartDateForDemandRate>
+                          <ApplicableEndDateForDemandRate>--05-31</ApplicableEndDateForDemandRate>
+                          <EnergyCostRate>0.053140</EnergyCostRate>
+                          <ElectricDemandRate>0.000000</ElectricDemandRate>
+                        </RatePeriod>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--10-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--12-31</ApplicableEndDateForEnergyRate>
+                          <ApplicableStartDateForDemandRate>--10-01</ApplicableStartDateForDemandRate>
+                          <ApplicableEndDateForDemandRate>--12-31</ApplicableEndDateForDemandRate>
+                          <EnergyCostRate>0.053140</EnergyCostRate>
+                          <ElectricDemandRate>0.000000</ElectricDemandRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://www.xcelenergy.com/company/rates_and_regulations/rates/rate_books</ReferenceForRateStructure>
+                  <FixedMonthlyCharge>16.880000</FixedMonthlyCharge>
+                </RateSchedule>
+              </RateSchedules>
+              <EIAUtilityID>12345</EIAUtilityID>
+              <UtilityName>Xcel Energy</UtilityName>
+              <UtilityMeterNumbers>
+                <UtilityMeterNumber>Some-meter-ID</UtilityMeterNumber>
+              </UtilityMeterNumbers>
+              <UtilityAccountNumber>some-account-number</UtilityAccountNumber>
+              <UtilityBillpayer>Building Owner</UtilityBillpayer>
+            </Utility>
+            <Utility ID="Utility-Natural-Gas">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Natural-Gas">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--12-31</ApplicableEndDateForEnergyRate>
+                          <EnergyCostRate>0.163600</EnergyCostRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://www.xcelenergy.com/company/rates_and_regulations/rates/rate_books</ReferenceForRateStructure>
+                  <FixedMonthlyCharge>43.880000</FixedMonthlyCharge>
+                </RateSchedule>
+              </RateSchedules>
+              <UtilityName>Xcel Energy</UtilityName>
+              <UtilityMeterNumbers>
+                <UtilityMeterNumber>Some-meter-ID</UtilityMeterNumber>
+              </UtilityMeterNumbers>
+              <UtilityAccountNumber>some-other-account-number</UtilityAccountNumber>
+              <UtilityBillpayer>Building Owner</UtilityBillpayer>
+            </Utility>
+          </Utilities>
+          <AuditorContactID IDref="Contact-Auditor"/>
+          <LinkedPremisesOrSystem>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremisesOrSystem>
+        </Report>
+      </Reports>
+      <Contacts>
+        <Contact ID="Contact-Owner">
+          <ContactRoles>
+            <ContactRole>Owner</ContactRole>
+          </ContactRoles>
+          <ContactName>The dude</ContactName>
+          <ContactCompany>Some big company</ContactCompany>
+          <ContactTelephoneNumbers>
+            <ContactTelephoneNumber>
+              <TelephoneNumber>123-456-7890</TelephoneNumber>
+            </ContactTelephoneNumber>
+          </ContactTelephoneNumbers>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.dude@somebigco.net</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+        <Contact ID="Contact-Auditor">
+          <ContactRoles>
+            <ContactRole>Energy Auditor</ContactRole>
+          </ContactRoles>
+          <ContactName>The lady</ContactName>
+          <ContactCompany>Auditeers</ContactCompany>
+          <ContactTelephoneNumbers>
+            <ContactTelephoneNumber>
+              <TelephoneNumber>123-456-7890</TelephoneNumber>
+            </ContactTelephoneNumber>
+          </ContactTelephoneNumbers>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.lady@the-three-auditeers.com</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+      </Contacts>
+    </Facility>
+  </Facilities>
+</BuildingSync>

--- a/spec/tests/model_articulation_test/facility_spec.rb
+++ b/spec/tests/model_articulation_test/facility_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe 'Facility Scenario Parsing' do
   end
 end
 
-RSpec.describe 'Facility Systems Mapping' do
+RSpec.describe 'Facility Systems' do
   before(:all) do
     # -- Setup
     @ns = 'auc'
@@ -184,33 +184,20 @@ RSpec.describe 'Facility Systems Mapping' do
     @facility = BuildingSync::Facility.new(facility_xml, @ns)
   end
   describe 'with systems defined' do
-    it 'should be of the correct data structure' do
-      # -- Assert
-      expect(@facility.systems_map).to be_an_instance_of(Hash)
-    end
-    it 'should have the correct keys' do
-      # -- Assert correct keys get created
-      expected_keys = ['HVACSystems', 'LightingSystems', 'PlugLoads']
-      expected_keys.each do |k|
-        expect(@facility.systems_map.key?(k)).to be true
-      end
-    end
-
     it 'values should be of the correct type and size' do
       # -- Assert values of keys are correct type and size
-      expect(@facility.systems_map['HVACSystems']).to be_an_instance_of(Array)
-      expect(@facility.systems_map['LightingSystems']).to be_an_instance_of(Array)
-      expect(@facility.systems_map['PlugLoads']).to be_an_instance_of(Array)
-      expect(@facility.systems_map['HVACSystems'].size).to eq(2)
-      expect(@facility.systems_map['LightingSystems'].size).to eq(1)
-      expect(@facility.systems_map['PlugLoads'].size).to eq(1)
+      expect(@facility.hvac_systems).to be_an_instance_of(Array)
+      expect(@facility.lighting_systems).to be_an_instance_of(Array)
+      expect(@facility.load_systems).to be_an_instance_of(Array)
+      expect(@facility.hvac_systems.size).to eq(2)
+      expect(@facility.lighting_systems.size).to eq(1)
+      expect(@facility.load_systems.size).to eq(1)
     end
 
     it 'values in array should be of the correct type' do
-      # Only HVACSystem and LightingSystem should be typed as BSync element types (for now)
-      expect(@facility.systems_map['HVACSystems'][0]).to be_an_instance_of(BuildingSync::HVACSystem)
-      expect(@facility.systems_map['LightingSystems'][0]).to be_an_instance_of(BuildingSync::LightingSystemType)
-      expect(@facility.systems_map['PlugLoads'][0]).to be_an_instance_of(REXML::Element)
+      expect(@facility.hvac_systems[0]).to be_an_instance_of(BuildingSync::HVACSystem)
+      expect(@facility.lighting_systems[0]).to be_an_instance_of(BuildingSync::LightingSystemType)
+      expect(@facility.load_systems[0]).to be_an_instance_of(BuildingSync::LoadsSystem)
     end
   end
   describe 'with no systems defined' do

--- a/spec/tests/model_articulation_test/facility_spec.rb
+++ b/spec/tests/model_articulation_test/facility_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'Facility Systems' do
     @ns = 'auc'
     g = BuildingSync::Generator.new
     doc = g.create_minimum_snippet('Retail')
-    doc_no_systems = g.create_minimum_snippet('Retail)')
+    doc_no_systems = g.create_minimum_snippet('Retail')
     @facility_no_systems_xml = g.get_first_facility_element(doc_no_systems)
 
     g.add_hvac_system_to_first_facility(doc, 'HVACSystem-1', 'VAV with Hot Water Reheat')

--- a/spec/tests/model_articulation_test/lighting_system_type_spec.rb
+++ b/spec/tests/model_articulation_test/lighting_system_type_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe 'LightingSystemType' do
     @facility = BuildingSync::Facility.new(facility_xml, ns)
 
     # -- Assert - No systems have been added
-    expect(@facility.systems_map.empty?).to be true
     @facility.determine_open_studio_standard(@std)
 
     # Add a blank lighting system to the facility and link it to the building
@@ -81,10 +80,8 @@ RSpec.describe 'LightingSystemType' do
     @lighting_system = @facility.add_blank_lighting_system(building_id, 'Building')
 
     # -- Assert Lighting System has been properly added
-    expect(@facility.systems_map.key?('LightingSystems')).to be true
-    expect(@facility.systems_map['LightingSystems'].size).to eq(1)
-    expect(@facility.systems_map['LightingSystems'][0]).to be @lighting_system
-    expect(@lighting_system.xget_linked_premises).to eq('Building' => ['Building1'])
+    expect(@facility.lighting_systems.size).to eq(1)
+    expect(@facility.lighting_systems[0].xget_linked_premises).to eq('Building' => ['Building1'])
 
     # we need to create a site and call the generate_baseline_osm method in order to set the space types in the model, why are those really needed?
     @facility.generate_baseline_osm(@epw_file_path, @output_path, @std)

--- a/spec/tests/model_articulation_test/lighting_system_type_spec.rb
+++ b/spec/tests/model_articulation_test/lighting_system_type_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe 'LightingSystemType' do
     @lighting_system = @facility.add_blank_lighting_system(building_id, 'Building')
 
     # -- Assert Lighting System has been properly added
-    expect(@facility.lighting_systems.size).to eq(1)
-    expect(@facility.lighting_systems[0].xget_linked_premises).to eq('Building' => ['Building1'])
+    expect(@facility.lighting_systems.size).to eq(2)
+    expect(@facility.lighting_systems[1].xget_linked_premises).to eq('Building' => ['Building1'])
 
     # we need to create a site and call the generate_baseline_osm method in order to set the space types in the model, why are those really needed?
     @facility.generate_baseline_osm(@epw_file_path, @output_path, @std)

--- a/spec/tests/translator_sizing_run_spec.rb
+++ b/spec/tests/translator_sizing_run_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe 'BuildingSync' do
       ['building_151_n1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
       ## building_151_level1
-      ['building_151_level1.xml', CA_TITLE24, nil, 'v2.4.0'],
       ['building_151_level1.xml', ASHRAE90_1, nil, 'v2.4.0'],
-      ['building_151_level1.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['building_151_level1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
       # Building 151 multifamily
@@ -71,6 +69,12 @@ RSpec.describe 'BuildingSync' do
       ['DC GSA HeadquartersWithClimateZone.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['DC GSA HeadquartersWithClimateZone.xml', ASHRAE90_1, nil, 'v2.4.0'],
 
+      # L100 Audit
+      # None working
+
+      # BuildingSync Website Valid Schema
+      # None of these should work, see errors that get caught in next section.
+
       # #####################################
       # ## L100 Audit
       # Trace/BPT trap: 5 gets hit for following 2 lines
@@ -78,14 +82,6 @@ RSpec.describe 'BuildingSync' do
       # ['L100_Audit.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: 1ed4ea50-edc6-0131-1b8b-48e0eb16a403.  Please try a different weather file."],
       ['L100_Audit.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['L100_Audit.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
-
-      # #####################################
-      # ## Golden File
-      # Trace/BPT trap: 5 gets hit for following 2 lines
-      # ['Golden Test File.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
-      # ['Golden Test File.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
-      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
-      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
       # L000_OpenStudio_Pre-Simulation-01
       ['L000_OpenStudio_Pre-Simulation_01.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
@@ -124,6 +120,11 @@ RSpec.describe 'BuildingSync' do
       # file_name, standard, epw_path, schema_version, expected_error_message
 
       #####################################
+      ## building_151_level1
+      ['building_151_level1.xml', CA_TITLE24, nil, 'v2.4.0', "This is not a table"],
+      ['building_151_level1.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "This is not a table"],
+
+      #####################################
       ## BuildingSync Website Valid Schema
       ['BuildingSync Website Valid Schema.xml', CA_TITLE24, nil, 'v2.4.0', 'Building ID: Building001. OccupancyClassification must be defined at either the Site or Building level.'],
       ['BuildingSync Website Valid Schema.xml', ASHRAE90_1, nil, 'v2.4.0', 'Building ID: Building001. OccupancyClassification must be defined at either the Site or Building level.'],
@@ -140,7 +141,15 @@ RSpec.describe 'BuildingSync' do
       ####################################
       # DC GSA HeadquartersWithClimateZone
       ['DC GSA HeadquartersWithClimateZone.xml', CA_TITLE24, nil, 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES Pre-1978_LargeOffice' to create in CaliforniaTitle24"],
-      ['DC GSA HeadquartersWithClimateZone.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES Pre-1978_LargeOffice' to create in CaliforniaTitle24"],
+      ['DC GSA HeadquartersWithClimateZone.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES Pre-1978_LargeOffice' to create in CaliforniaTitle24"],      # #####################################
+
+      # #####################################
+      # ## Golden File
+      # Trace/BPT trap: 5 gets hit for following 2 lines
+      # ['Golden Test File.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
+      # ['Golden Test File.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
+      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24", false],
+      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24"],
 
       # #####################################
       # L000_OpenStudio_Pre-Simulation-01

--- a/spec/tests/translator_sizing_run_spec.rb
+++ b/spec/tests/translator_sizing_run_spec.rb
@@ -105,7 +105,11 @@ RSpec.describe 'BuildingSync' do
       # Office_Carolina
       ['Office_Carolina.xml', ASHRAE90_1, nil, 'v2.4.0'],
       ['Office_Carolina.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
-      ['Office_Carolina.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0']
+      ['Office_Carolina.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+
+      #####################################
+      ## Golden File
+      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
     ]
     tests_to_run.each do |test|
       it "File: #{test[0]}. Standard: #{test[1]}. EPW_Path: #{test[2]}. File Schema Version: #{test[3]}" do
@@ -148,8 +152,7 @@ RSpec.describe 'BuildingSync' do
       # Trace/BPT trap: 5 gets hit for following 2 lines
       # ['Golden Test File.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
       # ['Golden Test File.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
-      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24", false],
-      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24"],
+      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24"],
 
       # #####################################
       # L000_OpenStudio_Pre-Simulation-01

--- a/spec/tests/translator_sizing_run_spec.rb
+++ b/spec/tests/translator_sizing_run_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe 'BuildingSync' do
       ['L000_OpenStudio_Pre-Simulation_04.xml', ASHRAE90_1, nil, 'v2.4.0'],
       ['L000_OpenStudio_Pre-Simulation_04.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['L000_OpenStudio_Pre-Simulation_04.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+      ['example-smalloffice-level1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
       # Office_Carolina
       ['Office_Carolina.xml', ASHRAE90_1, nil, 'v2.4.0'],

--- a/spec/tests/translator_sizing_run_spec.rb
+++ b/spec/tests/translator_sizing_run_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe 'BuildingSync' do
       ['building_151_n1.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['building_151_n1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
+      ## building_151_level1
+      ['building_151_level1.xml', CA_TITLE24, nil, 'v2.4.0'],
+      ['building_151_level1.xml', ASHRAE90_1, nil, 'v2.4.0'],
+      ['building_151_level1.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+      ['building_151_level1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+
       # Building 151 multifamily
       ['building_151_multifamily.xml', ASHRAE90_1, nil, 'v2.4.0'],
       ['building_151_multifamily.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
@@ -65,11 +71,21 @@ RSpec.describe 'BuildingSync' do
       ['DC GSA HeadquartersWithClimateZone.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
       ['DC GSA HeadquartersWithClimateZone.xml', ASHRAE90_1, nil, 'v2.4.0'],
 
-      # L100 Audit
-      # None working
+      # #####################################
+      # ## L100 Audit
+      # Trace/BPT trap: 5 gets hit for following 2 lines
+      # ['L100_Audit.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: 1ed4ea50-edc6-0131-1b8b-48e0eb16a403.  Please try a different weather file."],
+      # ['L100_Audit.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: 1ed4ea50-edc6-0131-1b8b-48e0eb16a403.  Please try a different weather file."],
+      ['L100_Audit.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+      ['L100_Audit.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
-      # BuildingSync Website Valid Schema
-      # None of these should work, see errors that get caught in next section.
+      # #####################################
+      # ## Golden File
+      # Trace/BPT trap: 5 gets hit for following 2 lines
+      # ['Golden Test File.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
+      # ['Golden Test File.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
+      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
+      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
 
       # L000_OpenStudio_Pre-Simulation-01
       ['L000_OpenStudio_Pre-Simulation_01.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0'],
@@ -107,13 +123,6 @@ RSpec.describe 'BuildingSync' do
       # file_name, standard, epw_path, schema_version, expected_error_message
 
       #####################################
-      ## building_151_level1
-      ['building_151_level1.xml', CA_TITLE24, nil, 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-      ['building_151_level1.xml', ASHRAE90_1, nil, 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-      ['building_151_level1.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-      ['building_151_level1.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-
-      #####################################
       ## BuildingSync Website Valid Schema
       ['BuildingSync Website Valid Schema.xml', CA_TITLE24, nil, 'v2.4.0', 'Building ID: Building001. OccupancyClassification must be defined at either the Site or Building level.'],
       ['BuildingSync Website Valid Schema.xml', ASHRAE90_1, nil, 'v2.4.0', 'Building ID: Building001. OccupancyClassification must be defined at either the Site or Building level.'],
@@ -131,22 +140,6 @@ RSpec.describe 'BuildingSync' do
       # DC GSA HeadquartersWithClimateZone
       ['DC GSA HeadquartersWithClimateZone.xml', CA_TITLE24, nil, 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES Pre-1978_LargeOffice' to create in CaliforniaTitle24"],
       ['DC GSA HeadquartersWithClimateZone.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES Pre-1978_LargeOffice' to create in CaliforniaTitle24"],
-
-      # #####################################
-      # ## L100 Audit
-      # Trace/BPT trap: 5 gets hit for following 2 lines
-      # ['L100_Audit.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: 1ed4ea50-edc6-0131-1b8b-48e0eb16a403.  Please try a different weather file."],
-      # ['L100_Audit.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: 1ed4ea50-edc6-0131-1b8b-48e0eb16a403.  Please try a different weather file."],
-      ['L100_Audit.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-      ['L100_Audit.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
-
-      # #####################################
-      # ## Golden File
-      # Trace/BPT trap: 5 gets hit for following 2 lines
-      # ['Golden Test File.xml', CA_TITLE24, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
-      # ['Golden Test File.xml', ASHRAE90_1, nil, 'v2.4.0', "Error, cannot find local component for: fa8c9ff0-edc4-0131-a9f8-48e0eb16a403.  Please try a different weather file."],
-      ['Golden Test File.xml', CA_TITLE24, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "BuildingSync.Building.determine_open_studio_standard: ERROR: Did not find a class called 'CBES T24 2008_LargeOffice' to create in CaliforniaTitle24", false],
-      ['Golden Test File.xml', ASHRAE90_1, File.join(SPEC_WEATHER_DIR, 'USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw'), 'v2.4.0', "undefined method `add_internal_loads' for nil:NilClass"],
 
       # #####################################
       # L000_OpenStudio_Pre-Simulation-01


### PR DESCRIPTION
This PR fixes [read_and_create_initial_systems](https://github.com/BuildingSync/BuildingSync-gem/blob/281d4ff35db57292cbe2e562c9b56c27c82af6bd/lib/buildingsync/model_articulation/facility.rb#L211). This function is called in the init of a Facility. It reads the systems from the xml, and if it doesn't have any, provides some defaults.
 
Now, a close look at function will find a handful of questionable choices, but let's zero down on 3:
1. Defaults are used in an "all or nothing" fashion. That is, if you have no systems in your xml, you get a default hvac and lighting, ect. But if you have just hvac in the xml, no lighting for you. 
2. systems read from the xml are put in systems_map, default systems are put in class attr. This is confounding. Note no passing integration tests provide there own systems. That's not great
3. system_mapp allows for multiple hvacs to be defined (its an array), the class attrs only allow one.

In this PR I:
1. did away with the "all or nothing" fashion
2. got rid of system_map and always wrote to the class attrs
3. made the class attrs lists

why do not merge?
--
the change in how defaults breaks things a little. We are in converstations about how and where defaults should be set.
